### PR TITLE
Update definition of `electricity grid` and `energy transfer function`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - changed base IRI to https://openenergyplatform.org/
 - vehicle operational mode (bug fix) (#2046)
 - demand, efficiency value, final energy consumption value, process climate neutrality, material climate neutrality, primary energy consumption value, net electricity generation, climate neutrality criterion (#2063)
+- electricity grid, energy transfer function (#2073)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -90,32 +90,6 @@ Datatype: rdf:PlainLiteral
 Datatype: xsd:string
 
     
-ObjectProperty: <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
-
-    Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is used in the artificial object or process.",
-        rdfs:label "has energy participant"@en
-    
-    Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
-    
-    InverseOf: 
-        OEO_00020182
-    
-    
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
     
@@ -158,9 +132,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002092>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002233>
 
     Annotations: 
+        rdfs:comment "OEO adjustment: The range of this property has been changed from material entity to continuant. A subclass \"has physical input\" has been added for material entities and energies.",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/664
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
-        rdfs:comment "OEO adjustment: The range of this property has been changed from material entity to continuant. A subclass \"has physical input\" has been added for material entities and energies."
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702"
     
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
@@ -186,6 +160,32 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0003001>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
 
+    
+ObjectProperty: <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is used in the artificial object or process.",
+        rdfs:label "has energy participant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
+    
+    Range: 
+        OEO_00000150
+    
+    InverseOf: 
+        OEO_00020182
+    
     
 ObjectProperty: OEO_00000500
 
@@ -221,6 +221,8 @@ ObjectProperty: OEO_00000522
 ObjectProperty: OEO_00000523
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
+        rdfs:label "covers energy carrier"@en,
         OEO_00020426 "change range
 issue: https://github.com/OpenEnergyPlatform/ontology/pull/721
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/722
@@ -231,9 +233,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/852
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a study and the energy carrier it covers.",
-        rdfs:label "covers energy carrier"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubPropertyOf: 
         OEO_00000522
@@ -248,6 +248,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 ObjectProperty: OEO_00000524
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a greenhouse gas and the global warming potential it has.",
+        rdfs:label "has global warming potential"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/478
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
@@ -260,9 +262,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1410
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a greenhouse gas and the global warming potential it has.",
-        rdfs:label "has global warming potential"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubPropertyOf: 
         
@@ -296,13 +296,13 @@ ObjectProperty: OEO_00000525
 ObjectProperty: OEO_00000526
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between two neighbouring grid nodes in a supply grid.",
+        rdfs:label "is connected to"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1116
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between two neighbouring grid nodes in a supply grid.",
-        rdfs:label "is connected to"@en
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762"
     
     SubPropertyOf: 
         owl:topObjectProperty
@@ -320,13 +320,13 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762",
 ObjectProperty: OEO_00000527
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a supply grid g and a grid node n, in which n is part of g and n works as an extraction point of the supply system.",
+        rdfs:label "has sink"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1116
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a supply grid g and a grid node n, in which n is part of g and n works as an extraction point of the supply system.",
-        rdfs:label "has sink"@en
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762"
     
     SubPropertyOf: 
         OEO_00000526
@@ -344,13 +344,13 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762",
 ObjectProperty: OEO_00000528
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a supply grid g and a grid node n, in which n is part of g and n works as entry point to the supply system.",
+        rdfs:label "has source"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/66
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/478
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1116
-pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that holds between a supply grid g and a grid node n, in which n is part of g and n works as entry point to the supply system.",
-        rdfs:label "has source"@en
+pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762"
     
     SubPropertyOf: 
         OEO_00000526
@@ -368,6 +368,8 @@ pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/1762",
 ObjectProperty: OEO_00000529
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
+        rdfs:label "has normal state of matter"@en,
         OEO_00020426 "make subproperty of 'has state of matter'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001
@@ -378,9 +380,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has normal state of matter y if and only if a portion of x occurs in state y under normal pressure (1 bar) and normal temperature (0°C)",
-        rdfs:label "has normal state of matter"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubPropertyOf: 
         OEO_00000531
@@ -395,15 +395,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 ObjectProperty: OEO_00000530
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
+        rdfs:label "has origin"@en,
         OEO_00020426 "move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "x has the origin of y",
-        rdfs:label "has origin"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
@@ -418,14 +418,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 ObjectProperty: OEO_00000531
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
+        rdfs:label "has state of matter"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/989
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1001
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a portion of matter (x) and a state of matter (y) that indicates the state y of matter x under certain given conditions.",
-        rdfs:label "has state of matter"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/RO_0000086>
@@ -456,6 +456,8 @@ ObjectProperty: OEO_00010231
 ObjectProperty: OEO_00010234
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
+        rdfs:label "has energy input"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
@@ -465,9 +467,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
-        rdfs:label "has energy input"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubPropertyOf: 
         <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
@@ -479,6 +479,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 ObjectProperty: OEO_00010235
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
+        rdfs:label "has energy output"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
@@ -488,15 +490,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
-        rdfs:label "has energy output"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubPropertyOf: 
         <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
     
     Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
     
     Range: 
         OEO_00000150
@@ -514,6 +514,8 @@ ObjectProperty: OEO_00020180
 ObjectProperty: OEO_00020182
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
+        rdfs:label "is energy participant of"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
 
@@ -523,15 +525,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
-        rdfs:label "is energy participant of"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     Domain: 
         OEO_00000150
     
     Range: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
     
     InverseOf: 
         <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
@@ -540,10 +540,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 ObjectProperty: OEO_00020183
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an input of the artificial object or process.",
-        rdfs:label "is energy input to"@en
+        rdfs:label "is energy input to"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
     
     SubPropertyOf: 
         OEO_00020182
@@ -552,10 +552,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
 ObjectProperty: OEO_00020184
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an output of the artificial object or process.",
-        rdfs:label "is energy output of"@en
+        rdfs:label "is energy output of"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
     
     SubPropertyOf: 
         OEO_00020182
@@ -564,10 +564,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
 ObjectProperty: OEO_00020257
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as major energy input for p.",
-        rdfs:label "has main energy input"@en
+        rdfs:label "has main energy input"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
     
     SubPropertyOf: 
         OEO_00010234
@@ -582,10 +582,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
 ObjectProperty: OEO_00020258
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as input for p, but not as main input.",
-        rdfs:label "has auxilary energy input"@en
+        rdfs:label "has auxilary energy input"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
     
     SubPropertyOf: 
         OEO_00010234
@@ -600,10 +600,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
 ObjectProperty: OEO_00020259
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is the intended energy output of p, e.g. for further usage.",
-        rdfs:label "has main energy output"@en
+        rdfs:label "has main energy output"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
     
     SubPropertyOf: 
         OEO_00010235
@@ -618,10 +618,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
 ObjectProperty: OEO_00020260
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is an unintended, unwanted or unevitable output of p, e.g. waste heat.",
-        rdfs:label "has waste energy output"@en
+        rdfs:label "has waste energy output"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
     
     SubPropertyOf: 
         OEO_00010235
@@ -648,20 +648,20 @@ ObjectProperty: OEO_00140164
 ObjectProperty: OEO_00140175
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has gross output c iff: p has energy output c, and c is the total amount of energy generated during the process.",
+        rdfs:label "has gross output"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
 
 make subproperty of 'has energy output' and add domain:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has gross output c iff: p has energy output c, and c is the total amount of energy generated during the process.",
-        rdfs:label "has gross output"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubPropertyOf: 
         OEO_00010235
     
     Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
     
     Range: 
         OEO_00000150
@@ -670,20 +670,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
 ObjectProperty: OEO_00140176
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has net output c iff: p has energy output c, and c is the amount of energy delivered to the consumer or fed into a supply grid.",
+        rdfs:label "has net output"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
 
 make subproperty of 'has energy output' and add domain:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has net output c iff: p has energy output c, and c is the amount of energy delivered to the consumer or fed into a supply grid.",
-        rdfs:label "has net output"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubPropertyOf: 
         OEO_00010235
     
     Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
     
     Range: 
         OEO_00000150
@@ -841,6 +841,12 @@ Class: <http://purl.obolibrary.org/obo/UO_1000223>
 Class: OEO_00000001
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_33292",
+        rdfs:label "fuel role"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
 
@@ -858,13 +864,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel role is a role of a portion of matter that has the disposition to be an energy carrier and is used in a process that releases the carried energy by transforming the portion of matter into a different kind of portion of matter in a way that releases heat or does work.",
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_33292",
-        rdfs:label "fuel role"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>,
@@ -879,21 +879,21 @@ Class: OEO_00000003
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000072,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
+        OEO_00000503 some OEO_00000072
     
     
 Class: OEO_00000004
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biogas power plant is a biofuel power plant that has biogas power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Biogaskraftwerk"@de,
-        rdfs:label "biogas power plant"@en
+        rdfs:label "biogas power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000073,
@@ -914,13 +914,6 @@ Class: OEO_00000005
 Class: OEO_00000006
 
     Annotations: 
-        OEO_00020426 "move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon dioxide is a portion of matter with the chemical formula CO2. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kohlendioxid"@de,
@@ -928,7 +921,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_16526",
-        rdfs:label "carbon dioxide"@en
+        rdfs:label "carbon dioxide"@en,
+        OEO_00020426 "move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000331,
@@ -939,15 +939,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000007
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy is energy that is stored in the chemical bonds of a substance, which can be released by a chemical reaction.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "chemische Energie"@de,
         rdfs:label "chemical energy"@en,
@@ -958,7 +949,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000023>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000023>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/174
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/214
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000150
@@ -967,31 +967,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000008
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power unit is a power generating unit using coal as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kohlekraftwerksblock"@de,
-        rdfs:label "coal power unit"@en
+        rdfs:label "coal power unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000088,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396,
+        OEO_00000503 some OEO_00000088
     
     
 Class: OEO_00000009
 
     Annotations: 
-        OEO_00020426 "fix energy axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1281
-pull: https://github.com/OpenEnergyPlatform/ontology/pulls/1282",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric heat pump is a heat pump that uses electrical energy as drive energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "elektrische Wärmepumpe"@de,
-        rdfs:label "electric heat pump"@en
+        rdfs:label "electric heat pump"@en,
+        OEO_00020426 "fix energy axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1281
+pull: https://github.com/OpenEnergyPlatform/ontology/pulls/1282"
     
     SubClassOf: 
         OEO_00000212,
@@ -1023,6 +1023,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000011
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
+        rdfs:comment "formerly called energy transformer and formerly called energy converting device",
+        rdfs:label "energy converting component"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
 
@@ -1044,21 +1047,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy converting component is an artificial object that is usually a discrete part of an energy transformation unit with the function of transforming, transferring or changing a certain type of energy."@en,
-        rdfs:comment "formerly called energy transformer and formerly called energy converting device",
-        rdfs:label "energy converting component"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000061,
-        OEO_00010235 some OEO_00010114,
         <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00020102,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
+        OEO_00010235 some OEO_00010114
     
     
 Class: OEO_00000012
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage function is the function of an artificial object that has been engineered to contain energy for later usage whereby input energy and usable output energy are of the same type.",
+        rdfs:label "energy storage function"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
 
@@ -1068,9 +1070,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage function is the function of an artificial object that has been engineered to contain energy for later usage whereby input energy and usable output energy are of the same type.",
-        rdfs:label "energy storage function"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00000151,
@@ -1095,17 +1095,17 @@ Class: OEO_00000013
 Class: OEO_00000014
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "fossiler Brennstoff"@de,
+        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
+        rdfs:label "fossil combustion fuel"@en,
         OEO_00020426 "move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil combustion fuel is a combustion fuel with the origin fossil.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "fossiler Brennstoff"@de,
-        rdfs:comment "This class is used to implement the subset relationship between origins fossil and geogenic: Every object with the origin fossil also has the origin geogenic.",
-        rdfs:label "fossil combustion fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00000099
@@ -1126,51 +1126,53 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000016
 
     Annotations: 
-        OEO_00020426 "Improve axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1337
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1340",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell is a generator that converts chemical energy into electricity using redox reactions.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstoffzelle"@de,
-        rdfs:label "fuel cell"@en
+        rdfs:label "fuel cell"@en,
+        OEO_00020426 "Improve axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1337
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1340"
     
     SubClassOf: 
         OEO_00000188,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00000503 some OEO_00000099,
-        OEO_00010234 some OEO_00000007,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140034,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140034
+        OEO_00000503 some OEO_00000099,
+        OEO_00010234 some OEO_00000007
     
     
 Class: OEO_00000017
 
     Annotations: 
-        OEO_00020426 "Add 'gas power unit' as alternative term:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362/",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas fired power unit is a power generating unit using gas as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gaskraftwerksblock"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "gas power unit"@en,
-        rdfs:label "gas fired power unit"@en
+        rdfs:label "gas fired power unit"@en,
+        OEO_00020426 "Add 'gas power unit' as alternative term:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362/"
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some 
-            (OEO_00000173
-             and (OEO_00000529 value OEO_00000182)),
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
+        OEO_00000503 some 
+            (OEO_00000173
+             and (OEO_00000529 value OEO_00000182))
     
     
 Class: OEO_00000019
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
+        rdfs:label "geothermal power unit"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752
 
@@ -1180,24 +1182,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
 
 Add function:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power unit is a power unit using geothermal heat.",
-        rdfs:label "geothermal power unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437"
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00010234 some OEO_00000191,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388,
+        OEO_00010234 some OEO_00000191
     
     
 Class: OEO_00000020
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Treibhausgas"@de,
+        rdfs:label "greenhouse gas"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
 
@@ -1210,10 +1213,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1410
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas is a portion of matter that has the disposition to contribute to the greenhouse effect.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Treibhausgas"@de,
-        rdfs:label "greenhouse gas"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00000331
@@ -1240,20 +1240,20 @@ Class: OEO_00000021
 Class: OEO_00000022
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power unit is a power generating unit using hydrogen as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserstoffkraftwerksblock"@de,
-        rdfs:label "hydrogen power unit"@en
+        rdfs:label "hydrogen power unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000220,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000222
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000222,
+        OEO_00000503 some OEO_00000220
     
     
 Class: OEO_00000024
@@ -1271,9 +1271,6 @@ Class: OEO_00000024
 Class: OEO_00000025
 
     Annotations: 
-        OEO_00020426 "classification changed:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Methane is a hydrocarbon with the chemical formula CH4. It has a gaseous normal state of matter. It occurs naturally in the atmosphere as a trace gas and can work as a greenhouse gas. As it can be oxidised it can be used as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CH4",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Methan"@de,
@@ -1281,7 +1278,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805",
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_16183",
-        rdfs:label "methane"@en
+        rdfs:label "methane"@en,
+        OEO_00020426 "classification changed:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
     
     SubClassOf: 
         OEO_00140159,
@@ -1331,10 +1331,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000028
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear energy carrier is an energy carrier used in nuclear power stations to produce heat for steam turbines. Heat is created when the nuclear fuel undergoes nuclear fission.",
-        rdfs:label "nuclear energy carrier disposition"@en
+        rdfs:label "nuclear energy carrier disposition"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     SubClassOf: 
         OEO_00000151
@@ -1343,20 +1343,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
 Class: OEO_00000029
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power unit is a power generating unit using nuclear fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kernkraftwerksblock"@de,
-        rdfs:label "nuclear power unit"@en
+        rdfs:label "nuclear power unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000302,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396,
+        OEO_00000503 some OEO_00000302
     
     
 Class: OEO_00000030
@@ -1369,20 +1369,23 @@ Class: OEO_00000030
     SubClassOf: 
         OEO_00000334,
         
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-https://github.com/OpenEnergyPlatform/ontology/pull/1024"
-        OEO_00000503 some 
-            (OEO_00000181 or OEO_00000183),
-        
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+https://github.com/OpenEnergyPlatform/ontology/pull/1024"
+        OEO_00000503 some 
+            (OEO_00000181 or OEO_00000183)
     
     
 Class: OEO_00000031
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an energy transformation unit consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Kraftwerk"@de,
+        rdfs:label "power plant"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
 
@@ -1400,10 +1403,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant is an energy transformation unit consisting of power generating units and a grid component that feeds electric energy into an electric grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Kraftwerk"@de,
-        rdfs:label "power plant"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00020102
@@ -1420,6 +1420,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000032
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic cell (PV cell) is a generator that converts solar energy into electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PV cell"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Photovoltaikzelle"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Solarzelle"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "solar cell"@en,
+        rdfs:label "photovoltaic cell"@en,
         OEO_00020426 "change produces axiom to 'has energy output'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
@@ -1430,36 +1436,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228
 
 Update definition, label and axioms, add alternative terms:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1152
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1220",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic cell (PV cell) is a generator that converts solar energy into electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PV cell"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Photovoltaikzelle"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Solarzelle"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "solar cell"@en,
-        rdfs:label "photovoltaic cell"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1220"
     
     SubClassOf: 
         OEO_00000188,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010234 some OEO_00000384,
-        OEO_00010235 some OEO_00000139,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020048
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020048,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010234 some OEO_00000384,
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00000033
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable fuel is a fuel that has a renewable origin and an renewable energy carrier disposition",
         <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbarer Brennstoff"@de,
-        rdfs:label "renewable fuel"@en
+        rdfs:label "renewable fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861"
     
     EquivalentTo: 
         OEO_00000173
@@ -1477,15 +1477,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000034
 
     Annotations: 
-        OEO_00020426 "Add function:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power unit is a power generating unit using solar power.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Solarkraftwerksblock"@de,
-        rdfs:label "solar power unit"@en
+        rdfs:label "solar power unit"@en,
+        OEO_00020426 "Add function:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437"
     
     SubClassOf: 
         OEO_00000334,
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782
@@ -1493,35 +1494,34 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782
 change uses energy axiom to 'has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
-        OEO_00010234 some OEO_00000384,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388
+        OEO_00010234 some OEO_00000384
     
     
 Class: OEO_00000035
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
+        rdfs:label "solar thermal power unit"@en,
         OEO_00020426 "change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power unit is a solar power unit that has solar thermal collectors as parts.",
-        rdfs:label "solar thermal power unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00000034,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000387,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000207,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000387
+        OEO_00010235 some OEO_00000207
     
     
 Class: OEO_00000036
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid biomass power plant is a biofuel power plant that has solid biomass power units as parts.",
-        rdfs:label "solid biomass power plant"@en
+        rdfs:label "solid biomass power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000073,
@@ -1557,11 +1557,11 @@ Class: OEO_00000038
 Class: OEO_00000039
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage function is an energy storage function with thermal energy as input and output.",
+        rdfs:label "thermal energy storage function"@en,
         OEO_00020426 "Improve definition and label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage function is an energy storage function with thermal energy as input and output.",
-        rdfs:label "thermal energy storage function"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348"
     
     SubClassOf: 
         OEO_00000012
@@ -1570,46 +1570,56 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00000040
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Uranium is a portion of matter that has the atomic number 92. It is a silver-grey metal.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Uran"@de,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_33499",
-        rdfs:label "uranium"@en
+        rdfs:label "uranium"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030003,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000028,
+        OEO_00000530 some OEO_00030003,
         OEO_00000529 value OEO_00000390
     
     
 Class: OEO_00000041
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power unit is a power generating unit using waste as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Müllkraftwerksblock"@de,
-        rdfs:label "waste power unit"@en
+        rdfs:label "waste power unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000439,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000396,
+        OEO_00000503 some OEO_00000439
     
     
 Class: OEO_00000042
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of a material entity that has been discarded after primary use.",
+        rdfs:label "waste role"@en,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000665>,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207
 
@@ -1623,17 +1633,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1638
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste role is a role of a material entity that has been discarded after primary use.",
-        rdfs:label "waste role"@en,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
-
-Convert to skos:closeMatch
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000665>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>,
@@ -1643,8 +1643,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000043
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind is a process of air naturally moving.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wind"@de,
         rdfs:label "wind"@en,
@@ -1655,7 +1653,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000793>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000793>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -1665,6 +1665,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000044
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind energy converting unit is a power generating unit that uses wind energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Windenergieanlage"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Windkraftanlage"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine"@en,
+        rdfs:label "wind energy converting unit"@en,
         OEO_00020426 "Issue: https://github.com/OpenEnergyPlatform/ontology/issues/753
 Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/754
 
@@ -1674,19 +1679,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
 Add function:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind energy converting unit is a power generating unit that uses wind energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Windenergieanlage"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Windkraftanlage"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine"@en,
-        rdfs:label "wind energy converting unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437"
     
     SubClassOf: 
         OEO_00000334,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010234 some OEO_00000446,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
@@ -1694,18 +1690,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000448,
         <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388,
         <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00020144,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00140000
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00140000,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00010234 some OEO_00000446
     
     
 Class: OEO_00000047
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An AC-line is a powerline for transferring high voltage alternating current."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wechselstromleitung"@de,
         rdfs:comment "undirected",
-        rdfs:label "AC-line"@en
+        rdfs:label "AC-line"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"
     
     SubClassOf: 
         OEO_00000253
@@ -1720,18 +1720,6 @@ Class: OEO_00000051
 Class: OEO_00000054
 
     Annotations: 
-        OEO_00020426 "add origin
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
-remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
-make subclass of gas mixture and improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009
-
-remove axiom 'is used by' some 'energy storage unit'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1495
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Air is a gas mixture that forms the Earth's atmosphere."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Luft"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Air_(disambiguation)",
@@ -1743,7 +1731,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002005>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002005>,
+        OEO_00020426 "add origin
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
+remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+make subclass of gas mixture and improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009
+
+remove axiom 'is used by' some 'energy storage unit'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1495
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499"
     
     SubClassOf: 
         OEO_00010236,
@@ -1755,8 +1755,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000055
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Air pollution occurs when harmful or excessive quantities of substances including gases, particles, and biological molecules are introduced into Earth's atmosphere."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Luftverschmutzung"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Air_pollution&oldid=877082014"@en,
@@ -1768,7 +1766,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02500037>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02500037>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410"
     
     SubClassOf: 
         OEO_00000330,
@@ -1778,11 +1778,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000056
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy is thermal energy that is stored in the ambient air, beneath the surface of solid earth or in surface water. It is captured by heat pumps."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Umgebungswärme"@de,
-        rdfs:label "ambient thermal energy"@en
+        rdfs:label "ambient thermal energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
     
     SubClassOf: 
         OEO_00000207
@@ -1812,6 +1812,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000061
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Artefakt"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "künstliches Objekt"@de,
+        rdfs:label "artificial object"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/86
 pull requests: https://github.com/OpenEnergyPlatform/ontology/pull/121 (artificial object definition)
 subclasses
@@ -1821,11 +1825,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/933
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An artificial object is an object that was deliberately manufactured by humans to address a particular purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Artefakt"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "künstliches Objekt"@de,
-        rdfs:label "artificial object"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000030>,
@@ -1847,9 +1847,6 @@ Class: OEO_00000062
 Class: OEO_00000066
 
     Annotations: 
-        OEO_00020426 "Add 'physical output of' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Aviation gasoline is gasoline used as motor spirit and prepared especially for aviation piston engines, with an octane number suited to the engine, a freezing point of -60 °C and a distillation range usually within the limits of 30 °C and 180 °C."@en,
         
             Annotations: OEO_00020426 "https://github.com/OpenEnergyPlatform/ontology/issues/1028
@@ -1857,7 +1854,10 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Flugzeugbenzin"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "aviation gasoline"@en
+        rdfs:label "aviation gasoline"@en,
+        OEO_00020426 "Add 'physical output of' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331"
     
     SubClassOf: 
         OEO_00000183,
@@ -1867,42 +1867,46 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1037"
 Class: OEO_00000068
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A battery is an energy storage object using different chemical or physical reactions to store energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Akku"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Batterie"@de,
-        rdfs:label "battery"@en
+        rdfs:label "battery"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801"
     
     SubClassOf: 
         OEO_00000159,
-        OEO_00010234 some OEO_00000139,
-        OEO_00010235 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140037,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010322
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010322,
+        OEO_00010234 some OEO_00000139,
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00000071
 
     Annotations: 
-        OEO_00020426 "redefine and change axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biodiesel is a portion of matter that has a liquid state of matter and has a diesel fuel role. It is produced from plants or animals and thus has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Biodiesel"@de,
-        rdfs:label "biodiesel"@en
+        rdfs:label "biodiesel"@en,
+        OEO_00020426 "redefine and change axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030001,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010240,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000530 some OEO_00030001,
         OEO_00000529 value OEO_00000256
     
     
 Class: OEO_00000072
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a combustion fuel that has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "biogener Brennstoff"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "biogenic combustion fuel"@en,
+        rdfs:label "biofuel"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/396
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/400
 
@@ -1922,11 +1926,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048
 
 delete 'renewable energy carrier disposition':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel is a combustion fuel that has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "biogener Brennstoff"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "biogenic combustion fuel"@en,
-        rdfs:label "biofuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409"
     
     EquivalentTo: 
         OEO_00000099
@@ -1934,8 +1934,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
     
     SubClassOf: 
         OEO_00000099,
-        OEO_00000530 some OEO_00030001,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000530 some OEO_00030001
     
     DisjointWith: 
         OEO_00000014
@@ -1944,10 +1944,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
 Class: OEO_00000073
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biofuel power plant is a power plant that has biofuel power units as parts.",
-        rdfs:label "biofuel power plant"@en
+        rdfs:label "biofuel power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000031,
@@ -1957,11 +1957,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000074
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-improve definition and make subclass of gas mixture:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biogas is a gas mixture produced by anaerobic digestion. It consists mainly of methane and carbon dioxide and can be used as fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Biogas"@de,
         rdfs:label "biogas"@en,
@@ -1972,21 +1967,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000556>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000556>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+improve definition and make subclass of gas mixture:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009"
     
     SubClassOf: 
         OEO_00010236,
         (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000006)
          and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025),
-        OEO_00000530 some OEO_00030001,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000530 some OEO_00030001,
         OEO_00000529 value OEO_00000182
     
     
 Class: OEO_00000075
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that has a liquid state of matter and has a gasoline fuel role. It consists of bioethanol, biomethanol and products of these two substances. It is made from vegetable or animal material and thus has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "bioethanol"@en,
+        rdfs:comment "biopetrol",
+        rdfs:label "biogasoline"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
 redefine and change axiom:
@@ -1994,19 +1999,14 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
 add editor note:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1028
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1037",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogasoline is a portion of matter that has a liquid state of matter and has a gasoline fuel role. It consists of bioethanol, biomethanol and products of these two substances. It is made from vegetable or animal material and thus has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "bioethanol"@en,
-        rdfs:comment "biopetrol",
-        rdfs:label "biogasoline"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1037"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030001,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020001,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010239,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000530 some OEO_00030001,
         OEO_00000529 value OEO_00000256
     
     
@@ -2026,11 +2026,6 @@ Class: OEO_00000077
 Class: OEO_00000084
 
     Annotations: 
-        OEO_00020426 "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
-add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Charcoal is a portion of matter produced from wood via pyrolysis. It has a solid state of matter and can be used as fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Holzkohle"@de,
         rdfs:label "charcoal"@en,
@@ -2041,14 +2036,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000560>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000560>,
+        OEO_00020426 "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030001,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000530 some OEO_00030001,
         OEO_00000529 value OEO_00000390
     
     
@@ -2071,21 +2071,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030002,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
+        OEO_00000530 some OEO_00030002,
         OEO_00000529 value OEO_00000390
     
     
 Class: OEO_00000089
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power plant is a power plant that has coal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kohlekraftwerk"@de,
         rdfs:label "coal power plant"@en,
@@ -2096,7 +2094,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000038>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000038>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000031,
@@ -2130,13 +2130,13 @@ Class: OEO_00000094
 Class: OEO_00000096
 
     Annotations: 
-        OEO_00020426 "Add alternative labels:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1406",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Colliery gas is natural gas found in coal mines (British English: colliery). The main component is methane. Synonyms are firedamp, mine gas. It is used as a fossil fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Grubengas"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "firedamp"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "mine gas"@en,
-        rdfs:label "colliery gas"@en
+        rdfs:label "colliery gas"@en,
+        OEO_00020426 "Add alternative labels:
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1406"
     
     SubClassOf: 
         OEO_00000292
@@ -2145,6 +2145,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1406",
 Class: OEO_00000097
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
+        rdfs:label "combustible energy carrier disposition"@en,
         OEO_00020426 "Add 'realized in' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1353
@@ -2155,9 +2157,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustible energy carrier is an energy carrier that releases energy from a material entity in form of heat or work, by chemical reaction with other substances.",
-        rdfs:label "combustible energy carrier disposition"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000151,
@@ -2167,6 +2167,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000099
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
+        rdfs:label "combustion fuel"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
 
@@ -2179,9 +2181,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by chemical reaction with other substances.",
-        rdfs:label "combustion fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00000173
@@ -2194,12 +2194,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000102
 
     Annotations: 
-        OEO_00020426 "add axiom to secondary energy carrier disposition
-issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed air is air that has been compressed to store energy. To discharge energy, the air is expanded."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "verdichtete Luft"@de,
-        rdfs:label "compressed air"@en
+        rdfs:label "compressed air"@en,
+        OEO_00020426 "add axiom to secondary energy carrier disposition
+issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"
     
     SubClassOf: 
         OEO_00000054,
@@ -2209,6 +2209,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00000115
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Rohöl"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "petroleum"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "crude oil"@en,
         OEO_00020426 "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 https://github.com/OpenEnergyPlatform/ontology/pull/1024
@@ -2219,16 +2224,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Crude oil is a portion of mater of fossil origin comprising a mixture of hydrocarbons and associated impurities, such as sulphur. It exists in the liquid phase under normal surface temperature and pressure and its physical characteristics (density, viscosity, etc.) are highly variable. This category includes field or lease condensate recovered from associated and non-associated gas where it is commingled with the commercial crude oil stream."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Rohöl"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "petroleum"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "crude oil"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030002,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
@@ -2236,17 +2235,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
+        OEO_00000530 some OEO_00030002,
         OEO_00000529 value OEO_00000256
     
     
 Class: OEO_00000117
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A dam is an artificial object that stops or restricts the flow of water or underground streams."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Staudamm"@de,
-        rdfs:label "dam"@en
+        rdfs:label "dam"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755"
     
     SubClassOf: 
         OEO_00000061,
@@ -2256,13 +2256,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
 Class: OEO_00000126
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An HVDC-line is a powerline for transferring high voltage direct current."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "HGÜ-Leitung"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Hochspannungsgleichstromübertragungsleitung"@de,
         rdfs:comment "directed",
-        rdfs:label "HVDC-line"@en
+        rdfs:label "HVDC-line"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"
     
     SubClassOf: 
         OEO_00000253
@@ -2274,11 +2274,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385",
 Class: OEO_00000129
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Grid transferred thermal energy is thermal energy that is transferred via the grid-bound heating process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "derived heat",
-        rdfs:label "grid transferred thermal energy"@en
+        rdfs:label "grid transferred thermal energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770"
     
     SubClassOf: 
         OEO_00000207,
@@ -2288,34 +2288,34 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00000131
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "fossiler Dieselkraftstoff"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "transport diesel"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "fossil diesel fuel"@en,
         OEO_00020426 "relabel and add axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
 
 Add 'physical output of' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Diesel fuel is gas diesel oil used on-road for diesel compression ignition (cars, trucks, etc.), usually of low sulphur content."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "fossiler Dieselkraftstoff"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "transport diesel"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "fossil diesel fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331"
     
     SubClassOf: 
         OEO_00000181,
-        OEO_00240025 some OEO_00010315,
-        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010240
+        <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010240,
+        OEO_00240025 some OEO_00010315
     
     
 Class: OEO_00000132
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
         <http://purl.obolibrary.org/obo/IAO_0000115> "District heating is a grid-bound heating transfer to residential or commercial buildings."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Fernwärme"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "district grid-bound heating",
-        rdfs:label "district heating"@en
+        rdfs:label "district heating"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770"
     
     SubClassOf: 
         OEO_00020073
@@ -2324,6 +2324,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00000139
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Elektroenergie"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "elektrische Energie"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
+        rdfs:label "electrical energy"@en,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000020>,
         OEO_00020426 "definition of electrical energy:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/224
 pull request:  https://github.com/OpenEnergyPlatform/ontology/pull/524
@@ -2346,21 +2360,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy is a form of energy derived from the potential or kinetic energy of charged particles."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Elektroenergie"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "elektrische Energie"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Electrical_energy"@en,
-        rdfs:label "electrical energy"@en,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
-
-Convert to skos:closeMatch
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000020>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000150,
@@ -2371,6 +2371,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000143
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that transfers electrical energy / electricity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Stromnetz"@de,
+        rdfs:label "electricity grid"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165
@@ -2390,10 +2393,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that distributes electrical energy / electricity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Stromnetz"@de,
-        rdfs:label "electricity grid"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
     SubClassOf: 
         OEO_00000200,
@@ -2404,6 +2404,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00000144
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
+        rdfs:label "electricity grid component"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
 
@@ -2412,9 +2414,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1360
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid component is a grid component that is part of an electricity grid."@en,
-        rdfs:label "electricity grid component"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00020006
@@ -2427,6 +2427,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000146
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric traction motors."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Elektrofahrzeug"@de,
+        rdfs:label "electric vehicle"@en,
         OEO_00020426 "https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
 
@@ -2436,11 +2440,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
 Adapt definition and convert to equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric vehicle (abbreviated as EV) is a vehicle that uses one or more electric traction motors."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "EV",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Elektrofahrzeug"@de,
-        rdfs:label "electric vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"
     
     EquivalentTo: 
         OEO_00010023
@@ -2454,6 +2454,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
 Class: OEO_00000147
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing by-products from human activity (e.g. production, distribution or consumption) into the environment."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Emission"@de,
+        rdfs:label "emission"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
 moved to oeo-shared
@@ -2461,10 +2464,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/956
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "emission is a process releasing by-products from human activity (e.g. production, distribution or consumption) into the environment."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Emission"@de,
-        rdfs:label "emission"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -2474,6 +2474,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000148
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor is a process attribute that describes the correlation of emissions and the activity causing that emission.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Emissionsfaktor"@de,
+        rdfs:label "emission factor"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/243
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/581
 moved to oeo-shared
@@ -2485,10 +2488,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor is a process attribute that describes the correlation of emissions and the activity causing that emission.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Emissionsfaktor"@de,
-        rdfs:label "emission factor"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846"
     
     SubClassOf: 
         OEO_00030019,
@@ -2506,6 +2506,8 @@ Class: OEO_00000150
 Class: OEO_00000151
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
+        rdfs:label "energy carrier disposition"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
@@ -2523,9 +2525,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier disposition is a disposition of an material entity that contains energy for conversion as usable energy."@en,
-        rdfs:label "energy carrier disposition"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
@@ -2536,6 +2536,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00000159
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Energiespeicher"@de,
+        rdfs:label "energy storage object"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/209
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/276
 
@@ -2543,10 +2546,7 @@ Make equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage object is an artificial object that has the function energy storage.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Energiespeicher"@de,
-        rdfs:label "energy storage object"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359"
     
     EquivalentTo: 
         OEO_00000061
@@ -2576,12 +2576,12 @@ Class: OEO_00000165
 Class: OEO_00000169
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A flow battery is a battery in which chemical energy is provided by two chemical components dissolved in liquids contained within the system and separated by a membrane. Ion exchange (accompanied by flow of electric current) occurs through the membrane while both liquids circulate in their own respective space."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "redox flow battery",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Flow_battery&oldid=907053515"@en,
-        rdfs:label "flow battery"@en
+        rdfs:label "flow battery"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801"
     
     SubClassOf: 
         OEO_00000068
@@ -2590,6 +2590,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000173
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and that has a fuel role.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstoff"@de,
+        rdfs:label "fuel"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
 add role fuel commodity
@@ -2609,10 +2612,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel is a portion of matter that has the disposition to be an energy carrier and that has a fuel role.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstoff"@de,
-        rdfs:label "fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001)
@@ -2626,10 +2626,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000174
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power plant is a power plant that has fueled power units as parts.",
-        rdfs:label "fueled power plant"@en
+        rdfs:label "fueled power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000175
@@ -2642,10 +2642,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
 Class: OEO_00000175
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fueled power unit is a power generating unit that uses fuel.",
-        rdfs:label "fueled power unit"@en
+        rdfs:label "fueled power unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306"
     
     EquivalentTo: 
         OEO_00000334
@@ -2659,6 +2659,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/306",
 Class: OEO_00000181
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is a portion of matter that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Gasöl"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "gas diesel oil"@en,
         OEO_00020426 "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 https://github.com/OpenEnergyPlatform/ontology/pull/1024
@@ -2669,26 +2673,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243
 
 Add 'physical output of' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gas/diesel oil is a portion of matter that is primarily a medium distillate distilling between 180 °C and 380 °C. Includes blending components. Several grades are available depending on uses."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Gasöl"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "gas diesel oil"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        OEO_00240025 some OEO_00010315,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000530 some OEO_00030002,
+        OEO_00240025 some OEO_00010315,
         OEO_00000529 value OEO_00000256
     
     
 Class: OEO_00000183
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
+        
+            Annotations: OEO_00020426 "https://github.com/OpenEnergyPlatform/ontology/issues/1028
+https://github.com/OpenEnergyPlatform/ontology/pull/1037"
+        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Benzin"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "petrol"@en,
+        rdfs:label "gasoline"@en,
         OEO_00020426 "make direct subclass of 'portion of matter' and preserve axioms from old class 'oil and petroleum products'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
 https://github.com/OpenEnergyPlatform/ontology/pull/1024
@@ -2703,36 +2712,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243
 
 Add 'physical output of' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gasoline (American English) or petrol (British English) is a portion of matter in the form of a transparent petroleum-derived liquid that is used primarily as a fuel in spark-ignited internal combustion engines. It consists mostly of organic compounds obtained by the fractional distillation of petroleum, enhanced with a variety of additives.",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "https://en.wikipedia.org/w/index.php?title=Gasoline&oldid=867948640",
-        
-            Annotations: OEO_00020426 "https://github.com/OpenEnergyPlatform/ontology/issues/1028
-https://github.com/OpenEnergyPlatform/ontology/pull/1037"
-        <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Benzin"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "petrol"@en,
-        rdfs:label "gasoline"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        OEO_00240025 some OEO_00010315,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010239,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000530 some OEO_00030002,
+        OEO_00240025 some OEO_00010315,
         OEO_00000529 value OEO_00000256
     
     
 Class: OEO_00000184
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas power plant is a power plant that has gas fired power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gaskraftwerk"@de,
-        rdfs:label "gas power plant"@en
+        rdfs:label "gas power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000031,
@@ -2742,25 +2742,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000185
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that participates in a gas turbine process. It is also called combustion turbine.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Gasturbine"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "combustion turbine"@en,
+        rdfs:label "gas turbine"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
 
 change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine is a turbine that participates in a gas turbine process. It is also called combustion turbine.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Gasturbine"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "combustion turbine"@en,
-        rdfs:label "gas turbine"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00000425,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00000503 some OEO_00000099,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
@@ -2768,7 +2762,13 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00310027
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00310027,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        OEO_00000503 some OEO_00000099
     
     
 Class: OEO_00000186
@@ -2788,6 +2788,10 @@ The production of other coal gases (i.e. coke oven gas, blast furnace gas and ox
 Class: OEO_00000188
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting component that converts other forms of energy into electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Generator"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Stromerzeuger"@de,
+        rdfs:label "generator"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
 axiom
@@ -2799,33 +2803,29 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A generator is an energy converting component that converts other forms of energy into electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Generator"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Stromerzeuger"@de,
-        rdfs:label "generator"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000011,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000334,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00000334
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00000189
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geographic coordinate system.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "geographische Koordinate"@de,
+        rdfs:label "geographic coordinate"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/795
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/803
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A geographic coordinate is an information content entity explicitly stating the geographic position of a zero-dimensional spatial region on Earth, by using a set of numbers with respect to a geographic coordinate system.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "geographische Koordinate"@de,
-        rdfs:label "geographic coordinate"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000030>,
@@ -2835,8 +2835,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000191
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal energy is thermal energy that is released from within the earth's crust.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Erdwärme"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Geothermie"@de,
@@ -2848,7 +2846,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000034>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000034>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739"
     
     SubClassOf: 
         OEO_00000207,
@@ -2858,8 +2858,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000192
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power plant is a power plant that has geothermal power units as parts."@en,
         rdfs:label "geothermal power plant"@en,
         
@@ -2869,7 +2867,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002215>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002215>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000031,
@@ -2879,6 +2879,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000198
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_76413",
+        rdfs:label "greenhouse effect disposition"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
 
@@ -2900,13 +2906,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The greenhouse effect disposition is the disposition of a gas to contribute to the greenhouse effect, when it is emitted into the atmosphere.",
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_76413",
-        rdfs:label "greenhouse effect disposition"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
@@ -2919,6 +2919,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000199
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Treibhausgasemission"@de,
+        rdfs:label "greenhouse gas emission"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
@@ -2939,10 +2942,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Treibhausgasemission"@de,
-        rdfs:label "greenhouse gas emission"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
     EquivalentTo: 
         OEO_00000147
@@ -2952,6 +2952,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00000200
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is a supply system of systematically connected artificial objects that can work as a supply system.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Versorgungsnetz"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "grid"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "network"@en,
+        rdfs:label "supply grid"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
 
@@ -2964,12 +2969,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 make subclass of supply system:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply grid is a supply system of systematically connected artificial objects that can work as a supply system.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Versorgungsnetz"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "grid"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "network"@en,
-        rdfs:label "supply grid"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947"
     
     SubClassOf: 
         OEO_00030025
@@ -2993,11 +2993,11 @@ Class: OEO_00000204
 Class: OEO_00000205
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power plant is a coal power plant that has hard coal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Steinkohlekraftwerk"@de,
-        rdfs:label "hard coal power plant"@en
+        rdfs:label "hard coal power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000089,
@@ -3007,6 +3007,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000206
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
+        rdfs:label "hardware"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350
 
@@ -3015,9 +3017,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
-        rdfs:label "hardware"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000061,
@@ -3027,16 +3027,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000207
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Thermal energy is the energy that a material entity contains in the undirected motion of its constituent parts (e.g. molecules and atoms)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wärme"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "thermische Energie"@de,
@@ -3048,7 +3038,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000032>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000032>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en
     
     SubClassOf: 
         OEO_00000150
@@ -3057,6 +3057,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000210
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting component that converts other forms of energy into useful heat.",
+        rdfs:label "heater"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
 
@@ -3065,9 +3067,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/993
 
 change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heater is an energy converting component that converts other forms of energy into useful heat.",
-        rdfs:label "heater"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00000011,
@@ -3080,14 +3080,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00000211
 
     Annotations: 
-        OEO_00020426 "Add 'physical output of' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Heating oil is gas diesel oil for industrial and commercial uses, marine diesel and diesel used in rail traffic, other gas oil, including heavy gas oils which distil between 380 °C and 540 °C and which are used as petrochemical feedstocks."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Heizöl"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "other gas oil"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "heating oil"@en
+        rdfs:label "heating oil"@en,
+        OEO_00020426 "Add 'physical output of' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331"
     
     SubClassOf: 
         OEO_00000181,
@@ -3108,6 +3108,9 @@ Class: OEO_00000212
 Class: OEO_00000218
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy is kinetic energy of moving liquid water which can result directly from its potential energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserkraft"@de,
+        rdfs:label "hydro energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/681
 change axiom from participates in to is energy participant of
@@ -3118,13 +3121,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1620
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy is kinetic energy of moving liquid water which can result directly from its potential energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserkraft"@de,
-        rdfs:label "hydro energy"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00230020,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -3132,8 +3133,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00110002,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441
+        OEO_00020182 some OEO_00110002
     
     
 Class: OEO_00000219
@@ -3153,7 +3153,6 @@ Class: OEO_00000219
 Class: OEO_00000220
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen is a portion of matter with the chemical formula H2. It has a gaseous normal state of matter. As it can be oxidised it can be used as a fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "H2",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserstoff"@de,
@@ -3161,7 +3160,8 @@ Class: OEO_00000220
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_18276",
-        rdfs:label "hydrogen"@en
+        rdfs:label "hydrogen"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134"
     
     SubClassOf: 
         OEO_00000331,
@@ -3173,11 +3173,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000221
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen power plant is a power plant that has hydrogen power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserstoffkraftwerk"@de,
-        rdfs:label "hydrogen power plant"@en
+        rdfs:label "hydrogen power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000031,
@@ -3187,14 +3187,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000222
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserstoffturbine"@de,
+        rdfs:label "hydrogen turbine"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/873
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/877
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen turbine is a gas turbine fueled with hydrogen."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserstoffturbine"@de,
-        rdfs:label "hydrogen turbine"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300"
     
     SubClassOf: 
         OEO_00000185,
@@ -3209,10 +3209,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000226
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An industrial waste fuel is waste fuel produced by industry."@en,
-        rdfs:label "industrial waste fuel"@en
+        rdfs:label "industrial waste fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961"
     
     SubClassOf: 
         OEO_00000439
@@ -3221,6 +3221,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00000240
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle that uses an internal combustion engine for propulsion.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Verbrennungsmotorfahrzeug"@de,
+        rdfs:label "internal combustion vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
 
@@ -3234,10 +3237,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315
 
 Add fuel tank axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion vehicle is a vehicle that uses an internal combustion engine for propulsion.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Verbrennungsmotorfahrzeug"@de,
-        rdfs:label "internal combustion vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356"
     
     EquivalentTo: 
         OEO_00010023
@@ -3247,23 +3247,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
     
     SubClassOf: 
         OEO_00010023,
-        OEO_00000503 some OEO_00000099,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320056
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320056,
+        OEO_00000503 some OEO_00000099
     
     
 Class: OEO_00000245
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International Air Transport Association (IATA).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "kerosene type jet fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
+        rdfs:label "jet fuel"@en,
         OEO_00020426 "Add 'physical output of' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
         OEO_00020426 "convert second label to alternative term:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1230
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1237",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Jet fuel is kerosene used for aviation turbine power units. It has the same distillation characteristics between 150 °C and 300 °C (generally not above 250 °C) and flash point as kerosene. In addition, it has particular specifications (such as freezing point) which are established by the International Air Transport Association (IATA).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "kerosene type jet fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "jet fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1237"
     
     SubClassOf: 
         OEO_00000246,
@@ -3273,6 +3273,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1237",
 Class: OEO_00000246
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is a portion of matter consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
+[...]
+
+Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Kerosin"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
+        rdfs:label "kerosene"@en,
         OEO_00020426 "Add 'physical output of' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
@@ -3282,37 +3289,30 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1024
 
 add axiom to secondary energy carrier disposition
 issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Kerosene, also known as paraffin, lamp oil, and coal oil (an obsolete term), is a portion of matter consisting of combustible hydrocarbon liquid which is derived from petroleum. It is widely used as a fuel in industry as well as households. It is sometimes spelled kerosine in scientific and industrial usage.
-[...]
-
-Kerosene is widely used to power jet engines of aircraft (jet fuel) and some rocket engines and is also commonly used as a cooking and lighting fuel and for fire toys such as poi. In parts of Asia, kerosene is sometimes used as fuel for small outboard motors or even motorcycles.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Kerosin"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Kerosene&oldid=867958484",
-        rdfs:label "kerosene"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        OEO_00240025 some OEO_00010315,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140159,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000530 some OEO_00030002,
+        OEO_00240025 some OEO_00010315,
         OEO_00000529 value OEO_00000256
     
     
 Class: OEO_00000248
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lithium-ion battery is a battery that is rechargeable and in which lithium ions move from the negative electrode to the positive electrode during discharge, and back when charging. Li-ion batteries use an intercalated lithium compound as one electrode material."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "LIB"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Li-ion battery"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Lithium-Ionen-Batterie"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Lithium-ion_battery&oldid=906786251"@en,
-        rdfs:label "lithium-ion battery"@en
+        rdfs:label "lithium-ion battery"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801"
     
     SubClassOf: 
         OEO_00000068
@@ -3349,8 +3349,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000252
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power plant is a coal power plant that has lignite power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Braunkohlenkraftwerk"@de,
         rdfs:label "lignite power plant"@en,
@@ -3361,7 +3359,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000040>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000040>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000089,
@@ -3371,6 +3371,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000253
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power line is a grid component link that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Stromleitung"@de,
+        rdfs:label "power line"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
 
@@ -3379,10 +3382,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1360
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power line is a grid component link that is an uninterrupted transmission system between two nodes in an electricity grid."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Stromleitung"@de,
-        rdfs:label "power line"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000255,
@@ -3392,6 +3392,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000255
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
+        rdfs:label "grid component link"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
 
@@ -3400,9 +3402,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1360
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component link is a grid component that serves as a connection between two other grid components."@en,
-        rdfs:label "grid component link"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en
     
     SubClassOf: 
         OEO_00020006
@@ -3414,12 +3414,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
 Class: OEO_00000257
 
     Annotations: 
-        OEO_00020426 "redefine definition and add equivalent
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air is air that has a liquid state of matter."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "verflüssigte Luft"@de,
-        rdfs:label "liquid air"@en
+        rdfs:label "liquid air"@en,
+        OEO_00020426 "redefine definition and add equivalent
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945"
     
     EquivalentTo: 
         OEO_00000054
@@ -3432,11 +3432,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
 Class: OEO_00000258
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid biofuel is a biofuel that has liquid as its normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "biogener Flüssigkraftstoff"@de,
-        rdfs:label "liquid biofuel"@en
+        rdfs:label "liquid biofuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00000072
@@ -3455,13 +3455,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000259
 
     Annotations: 
-        OEO_00020426 "reclassification and integration of molten state battery
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid-metal battery is a battery that consists of two molten metal alloys separated by an electrolyte. The rechargeable batteries are used for electric vehicles and potentially also for grid energy storage."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Flüssigmetallbatterie"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
-        rdfs:label "liquid-metal battery"@en
+        rdfs:label "liquid-metal battery"@en,
+        OEO_00020426 "reclassification and integration of molten state battery
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801"
     
     SubClassOf: 
         OEO_00000068
@@ -3470,33 +3470,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000263
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that is manufactured from coal. It is used as fossil fuel."@en,
+        rdfs:label "manufactured coal based gas"@en,
         OEO_00020426 "improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009
 add axiom to secondary energy carrier disposition
 issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured coal based gas is a gas mixture that is manufactured from coal. It is used as fossil fuel."@en,
-        rdfs:label "manufactured coal based gas"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"
     
     SubClassOf: 
         OEO_00010236,
-        OEO_00000530 some OEO_00030002,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000530 some OEO_00030002,
         OEO_00000529 value OEO_00000182
     
     
 Class: OEO_00000269
 
     Annotations: 
-        OEO_00020426 "Improve definition and classification:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane system is a power-to-gas system that implements the power-to-methane process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "methanation gas storage",
-        rdfs:label "power-to-methane system"@en
+        rdfs:label "power-to-methane system"@en,
+        OEO_00020426 "Improve definition and classification:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348"
     
     SubClassOf: 
         OEO_00000335,
@@ -3506,13 +3506,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00000282
 
     Annotations: 
-        OEO_00020426 "reclassification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A molten-salt battery is a battery that uses molten salts as an electrolyte and offers both a high energy density and a high power density."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Flüssigsalzbatterie"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Molten-salt_battery&oldid=900557096"@en,
-        rdfs:label "molten-salt battery"@en
+        rdfs:label "molten-salt battery"@en,
+        OEO_00020426 "reclassification
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801"
     
     SubClassOf: 
         OEO_00000068
@@ -3521,9 +3521,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000286
 
     Annotations: 
-        OEO_00020426 "Add 'physical output of' axiom:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Motor gasoline is gasoline consisting of a mixture of light hydrocarbons distilling between 35 °C and 215 °C. It is used as a fuel for land based spark ignition engines. Motor gasoline may include additives, oxygenates and octane enhancers, including lead compounds such as TEL and TML.
 
 Includes motor gasoline blending components (excluding additives/oxygenates), e.g. alkylates, isomerate, reformate, cracked gasoline destined for use as finished motor gasoline."@en,
@@ -3533,7 +3530,10 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Motorbenzin"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
-        rdfs:label "motor gasoline"@en
+        rdfs:label "motor gasoline"@en,
+        OEO_00020426 "Add 'physical output of' axiom:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331"
     
     SubClassOf: 
         OEO_00000183,
@@ -3543,10 +3543,10 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1037"
 Class: OEO_00000290
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A municipal waste fuel is waste fuel produced by households or non-industrial commercial activities."@en,
-        rdfs:label "municipal waste fuel"@en
+        rdfs:label "municipal waste fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961"
     
     SubClassOf: 
         OEO_00000439
@@ -3555,12 +3555,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00000292
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
-
-improve definition and make subclass of gas mixture and add disjoints:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Natural gas is a gas mixture occurring in underground deposits, whether liquefied or gaseous, and consisting mainly of methane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Erdgas"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Naturgas"@de,
@@ -3576,11 +3570,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000552>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000552>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/430
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
+
+improve definition and make subclass of gas mixture and add disjoints:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009"
     
     SubClassOf: 
         OEO_00010236,
-        OEO_00000530 some OEO_00030002,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
@@ -3588,21 +3587,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
+        OEO_00000530 some OEO_00030002,
         OEO_00000529 value OEO_00000182
     
     
 Class: OEO_00000293
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "negative Emission"@de,
+        rdfs:label "negative emission"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "negative Emission"@de,
-        rdfs:label "negative emission"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -3611,11 +3611,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00000296
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A grid node is a grid component of a supply grid where two or more links meet."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Netzknoten"@de,
-        rdfs:label "grid node"@en
+        rdfs:label "grid node"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en
     
     SubClassOf: 
         OEO_00020006
@@ -3639,13 +3639,13 @@ Class: OEO_00000297
 Class: OEO_00000298
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-methane volatile organic compound (NMVOC) is a volatile organic compound other than methane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "NMVOC"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "flüchtige organische Verbindungen außer Methan"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
-        rdfs:label "non-methane volatile organic compound"@en
+        rdfs:label "non-methane volatile organic compound"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356"
     
     SubClassOf: 
         OEO_00000437
@@ -3654,13 +3654,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00000299
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil municipal waste fuel is an municipal waste fuel that has a fossil origin."@en,
         
             Annotations: <http://purl.obolibrary.org/obo/IAO_0000116> "Old class name kept as alternative term"
         <http://purl.obolibrary.org/obo/IAO_0000118> "non renewable municipal waste fuel",
-        rdfs:label "fossil municipal waste fuel"@en
+        rdfs:label "fossil municipal waste fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961"
     
     EquivalentTo: 
         OEO_00000290
@@ -3673,11 +3673,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00000300
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
-conversion to nuclear binding energy
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear binding energy is the energy that is required to disassemble the nucleus of an atom into its component parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "kernphysikalische Bindungsenergie"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from https://en.wikipedia.org/w/index.php?title=Nuclear_binding_energy&oldid=1007327561"@en,
@@ -3689,7 +3684,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000025>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000025>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
+conversion to nuclear binding energy
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698"
     
     SubClassOf: 
         OEO_00000150,
@@ -3699,11 +3699,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000302
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear fuel is a fuel that realises its fuel role in processes that release energy in the form of heat or work by undergoing nuclear fission.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kernbrennstoff"@de,
-        rdfs:label "nuclear fuel"@en
+        rdfs:label "nuclear fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     EquivalentTo: 
         OEO_00000173
@@ -3717,15 +3717,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237",
 Class: OEO_00000303
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power plant is a power plant that has nuclear power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kernkraftwerk"@de,
         rdfs:label "nuclear power plant"@en,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002271>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002271>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000031,
@@ -3749,11 +3749,11 @@ Class: OEO_00000308
 Class: OEO_00000310
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A oil power plant is a power plant that has oil power units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ölkraftwerk"@de,
-        rdfs:label "oil power plant"@en
+        rdfs:label "oil power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000031,
@@ -3777,6 +3777,12 @@ Class: OEO_00000311
 Class: OEO_00000316
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Ursprung"@de,
+        rdfs:comment "* Biomass has a biogenic origin and if it is converted to biogas, the biogas inherits the the biogenic origin.
+* Hard coal has a fossil origin and if it is used in a coal power plant to generate electrical energy, the electrical energy inherits the fossil origin.
+* Wind energy has renewable origin and if it is converted to electrical energy using a wind turbine, the electrical energy inherits the renewable origin",
+        rdfs:label "origin"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
 
@@ -3802,13 +3808,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Origin is a quality of a portion of matter or energy based on where it comes from. It is inherited from its primary sources.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Ursprung"@de,
-        rdfs:comment "* Biomass has a biogenic origin and if it is converted to biogas, the biogas inherits the the biogenic origin.
-* Hard coal has a fossil origin and if it is used in a coal power plant to generate electrical energy, the electrical energy inherits the fossil origin.
-* Wind energy has renewable origin and if it is converted to electrical energy using a wind turbine, the electrical energy inherits the renewable origin",
-        rdfs:label "origin"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
@@ -3819,8 +3819,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00000318
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Particulate matter is a portion of matter consisting of small particles. It can act as an air pollutant."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Feinstaub"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "PM"@en,
@@ -3832,7 +3830,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000060>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000060>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356"
     
     SubClassOf: 
         OEO_00000331,
@@ -3843,8 +3843,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000320
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/942
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1003",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Peat is a or portion of matter that is a soft, porous or compressed, sedimentary deposit of plant origin with high water content (up to 90 % in the raw state) and can be used as combustion fuel. As the natural formation of peat takes at least centuries, peat is usually considered having a fossil origin."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Torf"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "REGULATION (EC) No 1099/2008 OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL of 22 October 2008 on energy statistics https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32008R1099&from=EN"@en,
@@ -3856,11 +3854,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00005774>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00005774>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/942
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1003"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030002,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000441,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
@@ -3868,6 +3867,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
+        OEO_00000530 some OEO_00030002,
         OEO_00000529 value OEO_00000390
     
     
@@ -3891,11 +3891,11 @@ Class: OEO_00000323
 Class: OEO_00000324
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic power plant is a solar power plant that has PV panels as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Photovoltaikanlage"@de,
-        rdfs:label "photovoltaic power plant"@en
+        rdfs:label "photovoltaic power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000386,
@@ -3905,8 +3905,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000330
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pollution is an emission with a negative effect on the environment or organisms."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Verschmutzung"@de,
         rdfs:label "pollution"@en,
@@ -3917,7 +3915,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02500036>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02500036>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234"
     
     SubClassOf: 
         OEO_00000147
@@ -3926,6 +3926,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000331
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is an aggregate of material entities that have a state of matter."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Portions of matter describe mass nouns like e.g. water, air and fuel. Mass nouns are uncountable, but portions of these can be quantified, like 1 glass of water, 1 m³ of air or 1 barrel of fuel. For further explanation please refer to: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
+        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
+        rdfs:label "portion of matter"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/227
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/279
 
@@ -3943,11 +3947,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1219
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A portion of matter is an aggregate of material entities that have a state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Portions of matter describe mass nouns like e.g. water, air and fuel. Mass nouns are uncountable, but portions of these can be quantified, like 1 glass of water, 1 m³ of air or 1 barrel of fuel. For further explanation please refer to: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        rdfs:comment "wiki page: https://github.com/OpenEnergyPlatform/ontology/wiki/Explanation-on-mass-nouns",
-        rdfs:label "portion of matter"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000027>,
@@ -3974,15 +3974,19 @@ Class: OEO_00000332
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1191
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
         OEO_00000072,
-        OEO_00000530 some OEO_00030001,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000530 some OEO_00030001,
         OEO_00000529 value OEO_00000390
     
     
 Class: OEO_00000333
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Leistung"@de,
+        rdfs:comment "Power is the derivative of energy transformation over time",
+        rdfs:label "power"@en,
         OEO_00020426 "classification:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/205
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/386
@@ -3997,11 +4001,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power is the process attribute that is the amount of energy transformed or transferred per time unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Leistung"@de,
-        rdfs:comment "Power is the derivative of energy transformation over time",
-        rdfs:label "power"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00030019,
@@ -4011,6 +4011,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00000334
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an energy transformation unit that has the function to produce electrical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Kraftwerksblock"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "block"@en,
+        rdfs:label "power generating unit"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/173
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/273
 
@@ -4034,11 +4038,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1360
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power generating unit is an energy transformation unit that has the function to produce electrical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Kraftwerksblock"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "block"@en,
-        rdfs:label "power generating unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en
     
     EquivalentTo: 
         OEO_00020102
@@ -4046,30 +4046,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
     
     SubClassOf: 
         OEO_00020102,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020107,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020107
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00000335
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
-
-created new parent class 'power-to-fuel system'
-https://github.com/OpenEnergyPlatform/ontology/issues/1477
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas system is a power-to-fuel system that implements a power-to-gas process. A water electrolyser is participating in the power-to-gas process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G",
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas",
-        rdfs:label "power-to-gas system"@en
+        rdfs:label "power-to-gas system"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
+
+created new parent class 'power-to-fuel system'
+https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483"
     
     SubClassOf: 
         OEO_00330009,
@@ -4080,6 +4080,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00000345
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is liquid water which was pumped into an upper reservoir and thus contains potential energy."@en,
+        rdfs:label "pumped water"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755
 
@@ -4089,36 +4091,34 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243
 
 add potential energy axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1174
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped water is liquid water which was pumped into an upper reservoir and thus contains potential energy."@en,
-        rdfs:label "pumped water"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348"
     
     SubClassOf: 
         OEO_00110000,
-        OEO_00000501 some OEO_00000399,
         <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00020045,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140076,
+        OEO_00000501 some OEO_00000399
     
     
 Class: OEO_00000348
 
     Annotations: 
-        OEO_00020426 "change produces energy axiom to 'has energy output':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A PV panel (photovoltaic panel) is a solar power unit absorbing sunlight as a source of energy to generate electricity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "PV-Modul"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Photovoltaikmodul"@de,
         rdfs:comment "A photovoltaic (PV) module is a packaged, connected assembly of typically 6x10 photovoltaic solar cells. Photovoltaic modules constitute the photovoltaic array of a photovoltaic system that generates and supplies solar electricity in commercial and residential applications.",
-        rdfs:label "PV panel"@en
+        rdfs:label "PV panel"@en,
+        OEO_00020426 "change produces energy axiom to 'has energy output':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00000034,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000032,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000032
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00000350
@@ -4127,6 +4127,9 @@ Class: OEO_00000350
 Class: OEO_00000356
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic municipal waste fuel is a municipal waste fuel that has a biogenic origin."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable municipal waste fuel",
+        rdfs:label "biogenic municipal waste fuel"@en,
         OEO_00020426 "remove origin 
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
 
@@ -4136,10 +4139,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
 
 rename class and change axiom:
 https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic municipal waste fuel is a municipal waste fuel that has a biogenic origin."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable municipal waste fuel",
-        rdfs:label "biogenic municipal waste fuel"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1048"
     
     EquivalentTo: 
         OEO_00000290
@@ -4168,16 +4168,16 @@ Class: OEO_00000361
 Class: OEO_00000374
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A superconducting magnetic energy storage (SMES) is an energy storage object that stores electrical energy in the magnetic field of a superconducting magnet.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "SMES",
+        rdfs:label "superconducting magnetic energy storage"@en,
         OEO_00020426 "Shorten definition and new label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1349
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1396
 
 add axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A superconducting magnetic energy storage (SMES) is an energy storage object that stores electrical energy in the magnetic field of a superconducting magnet.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "SMES",
-        rdfs:label "superconducting magnetic energy storage"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     SubClassOf: 
         OEO_00000159,
@@ -4187,13 +4187,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00000376
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium-ion battery is a rechargeable metal-ion battery that uses sodium ions as charge carriers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Natrium-Ionen-Batterie"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "SIB"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium-ion_battery&oldid=906459441"@en,
-        rdfs:label "sodium-ion battery"@en
+        rdfs:label "sodium-ion battery"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801"
     
     SubClassOf: 
         OEO_00000068
@@ -4202,14 +4202,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000377
 
     Annotations: 
-        OEO_00020426 "reclassification
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sodium–sulphur battery is a type of molten-salt battery constructed from liquid sodium (Na) and sulphur (S). This type of battery has a high energy density, high efficiency of charge/discharge and long cycle life, and is fabricated from inexpensive materials. The operating temperatures of 300 to 350 °C and the highly corrosive nature of the sodium polysulphides, primarily make them suitable for stationary energy storage applications. The cell becomes more economical with increasing size."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Natrium-Schwefel-Batterie"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "sodium–sulfur battery"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Sodium%E2%80%93sulfur_battery&oldid=900392594"@en,
-        rdfs:label "sodium-sulphur battery"@en
+        rdfs:label "sodium-sulphur battery"@en,
+        OEO_00020426 "reclassification
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801"
     
     SubClassOf: 
         OEO_00000282
@@ -4218,6 +4218,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/801",
 Class: OEO_00000384
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy is radiative energy of the sun."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Solarenergie"@de,
+        rdfs:label "solar energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
 restructure solar energy
@@ -4231,22 +4234,17 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1600
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1620
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy is radiative energy of the sun."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Solarenergie"@de,
-        rdfs:label "solar energy"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00020040,
-        OEO_00000530 some OEO_00030004,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00230021
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00230021,
+        OEO_00000530 some OEO_00030004
     
     
 Class: OEO_00000386
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power plant is a power plant that has solar power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Solarkraftwerk"@de,
         rdfs:label "solar power plant"@en,
@@ -4257,7 +4255,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000041>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000041>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000031,
@@ -4267,6 +4267,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00000387
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that converts solar energy to solar thermal energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Solarkollektor"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
+        rdfs:label "solar thermal collector"@en,
         OEO_00020426 "change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
@@ -4277,14 +4281,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228
 
 improve definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-https://github.com/OpenEnergyPlatform/ontology/pull/1432",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal collector is a heater that converts solar energy to solar thermal energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Solarkollektor"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Solar_thermal_collector&oldid=903948846"@en,
-        rdfs:label "solar thermal collector"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1432"
     
     SubClassOf: 
         OEO_00000210,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020047,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
@@ -4292,23 +4297,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000388,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020199,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020047
+        OEO_00010235 some OEO_00000388
     
     
 Class: OEO_00000388
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy is thermal energy that is the physical output of a solar thermal energy transformation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Solarthermie"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "solarthermische Energie"@de,
-        rdfs:label "solar thermal energy"@en
+        rdfs:label "solar thermal energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770"
     
     SubClassOf: 
         OEO_00000207,
@@ -4318,11 +4318,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00000389
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power plant is a solar power plant that has solar thermal power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "solarthermisches Kraftwerk"@de,
-        rdfs:label "solar thermal power plant"@en
+        rdfs:label "solar thermal power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000386,
@@ -4333,14 +4333,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000391
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid fossil fuel is a fossil fuel that has a solid state of matter under normal conditions.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "fossiler Festbrennstoff"@de,
+        rdfs:label "solid fossil fuel"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/106
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/164
 
 Update definition and axioms:
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solid fossil fuel is a fossil fuel that has a solid state of matter under normal conditions.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "fossiler Festbrennstoff"@de,
-        rdfs:label "solid fossil fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00000014
@@ -4355,6 +4355,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00000395
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A state of matter is a quality of a portion of matter that describes the distinct physical form in which the matter exists."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Aggregatzustand"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
+        rdfs:label "state of matter"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/38
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/39
 
@@ -4376,12 +4381,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1720
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A state of matter is a quality of a portion of matter that describes the distinct physical form in which the matter exists."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Four states of matter are observable in everyday life: solid, liquid, gas, and plasma. Many intermediate states are known to exist, such as liquid crystal, and some states only exist under extreme conditions."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Aggregatzustand"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=State_of_matter&oldid=903680856",
-        rdfs:label "state of matter"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
@@ -4391,15 +4391,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00000396
 
     Annotations: 
-        OEO_00020426 "change produces energy and uses energy axioms to 'has energy output' and ' has energy input':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam turbine is a turbine that converts heat from pressurised steam into rotational energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Dampfturbine"@de,
-        rdfs:label "steam turbine"@en
+        rdfs:label "steam turbine"@en,
+        OEO_00020426 "change produces energy and uses energy axioms to 'has energy output' and ' has energy input':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00000425,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00050020,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
@@ -4415,25 +4419,21 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00240000,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00050020
+        OEO_00010235 some OEO_00240000
     
     
 Class: OEO_00000399
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage unit is a grid component that stores energy."@en,
+        rdfs:label "energy storage unit"@en,
         OEO_00020426 "Make equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1338
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348
 
 Changed 'storage unit' to 'energy storage unit'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage unit is a grid component that stores energy."@en,
-        rdfs:label "energy storage unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486"
     
     EquivalentTo: 
         OEO_00020006
@@ -4472,12 +4472,12 @@ Class: OEO_00000419
 Class: OEO_00000420
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transformer is an electricity grid component that passively transfers electrical energy from one electrical circuit to another."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Transformator"@de,
         rdfs:comment "Source: https://en.wikipedia.org/wiki/Transformer"@en,
-        rdfs:label "transformer"@en
+        rdfs:label "transformer"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en
     
     SubClassOf: 
         OEO_00020006,
@@ -4487,15 +4487,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00000425
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting component that converts energy from a moving fluid flow into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Turbine"@de,
+        rdfs:label "turbine"@en,
         OEO_00020426 "use energy converting component in definition:
 https://github.com/OpenEnergyPlatform/ontology/pull/993
 
 change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A turbine is an energy converting component that converts energy from a moving fluid flow into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Turbine"@de,
-        rdfs:label "turbine"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00000011,
@@ -4515,15 +4515,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00000429
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an underground fuel storage object that stores hydrogen. Examples are underground caverns, salt domes and depleted oil/gas fields.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "unterirdischer Wasserstoffspeicher"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
+        rdfs:label "underground hydrogen storage object"@en,
         OEO_00020426 "Issue:https://github.com/OpenEnergyPlatform/ontology/issues/448
 Pull request: https://github.com/OpenEnergyPlatform/ontology/pull/462
 Improve definition and classification:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An underground hydrogen storage is an underground fuel storage object that stores hydrogen. Examples are underground caverns, salt domes and depleted oil/gas fields.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "unterirdischer Wasserstoffspeicher"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/w/index.php?title=Underground_hydrogen_storage&oldid=895350780",
-        rdfs:label "underground hydrogen storage object"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348"
     
     SubClassOf: 
         OEO_00010325,
@@ -4533,8 +4533,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00000437
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A volatile organic compound (VOC) is a portion of matter consisting of organic compounds that is capable of producing photochemical oxidants by reactions with nitrogen oxides in the presence of sunlight. Hence it can act as an air pollutant."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "VOC"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "flüchtige organische Verbindungen"@de,
@@ -4543,7 +4541,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_134179",
-        rdfs:label "volatile organic compound"@en
+        rdfs:label "volatile organic compound"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356"
     
     EquivalentTo: 
         OEO_00000025 or OEO_00000298
@@ -4562,17 +4562,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000439
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Abfallbrennstoff"@de,
+        rdfs:comment "The energy content of waste fuel is typically released by incineration or gasification. The energy content of nuclear waste is not considered as a waste fuel.",
+        rdfs:label "waste fuel"@en,
         OEO_00020426 "label and definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/132
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/207
 
 comment:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/629
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/631",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A waste fuel is a fuel in which the material entity is waste."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Abfallbrennstoff"@de,
-        rdfs:comment "The energy content of waste fuel is typically released by incineration or gasification. The energy content of nuclear waste is not considered as a waste fuel.",
-        rdfs:label "waste fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/631"
     
     EquivalentTo: 
         OEO_00000173
@@ -4590,11 +4590,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00000440
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waste power plant is a power plant that has waste power units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Müllkraftwerk"@de,
-        rdfs:label "waste power plant"@en
+        rdfs:label "waste power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000031,
@@ -4604,14 +4604,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000441
 
     Annotations: 
-        OEO_00020426 "definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/685
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/689
-add origin
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
-remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water is a portion of matter with the chemical formula H2O. It has a liquid normal state of matter.",
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1081
@@ -4626,7 +4618,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_15377",
-        rdfs:label "water"@en
+        rdfs:label "water"@en,
+        OEO_00020426 "definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/685
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/689
+add origin
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
+remove origin 
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861"
     
     SubClassOf: 
         OEO_00000331,
@@ -4637,6 +4637,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00000442
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting potential energy and kinetic energy of water into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserkraftturbine"@de,
+        rdfs:label "water turbine"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
@@ -4644,13 +4647,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
 
 change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water turbine is a turbine converting potential energy and kinetic energy of water into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserkraftturbine"@de,
-        rdfs:label "water turbine"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00000425,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110004,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
@@ -4662,16 +4666,15 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00240000,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110004
+        OEO_00010235 some OEO_00240000
     
     
 Class: OEO_00000446
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy is the kinetic energy of moving air."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Windenergie"@de,
+        rdfs:label "wind energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
 reclassify and change def
@@ -4687,31 +4690,28 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1600
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1620
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy is the kinetic energy of moving air."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Windenergie"@de,
-        rdfs:label "wind energy"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00230020,
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000054,
         OEO_00000530 some OEO_00030004,
         
             Annotations: OEO_00020426 "change axiom to 'participates in'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
         OEO_00020182 some OEO_00000043,
-        OEO_00020183 some OEO_00020043,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000054
+        OEO_00020183 some OEO_00020043
     
     
 Class: OEO_00000447
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind farm is a power plant that has wind energy converting units as parts."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Windpark"@de,
-        rdfs:label "wind farm"@en
+        rdfs:label "wind farm"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/750
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
     
     SubClassOf: 
         OEO_00000031,
@@ -4721,19 +4721,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752",
 Class: OEO_00000448
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Windrotor"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
+        rdfs:label "wind rotor"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/299
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/300
 
 change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A wind rotor (or wind turbine) is a turbine that converts the wind's kinetic energy into rotational energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Windrotor"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "wind turbine",
-        rdfs:label "wind rotor"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00000425,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020043,
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00020144,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
@@ -4745,26 +4750,21 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00240000,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020043,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00020144
+        OEO_00010235 some OEO_00240000
     
     
 Class: OEO_00000449
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood is a biomass from trees. It has a solid state of matter an can be used as fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Holz"@de,
+        rdfs:label "wood"@en,
         OEO_00020426 "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
 
 add dispositions:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Wood is a biomass from trees. It has a solid state of matter an can be used as fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Holz"@de,
-        rdfs:label "wood"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033"
     
     SubClassOf: 
         OEO_00010214,
@@ -4777,12 +4777,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1033",
 Class: OEO_00010000
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
-
-Adapt definition and axioms, add alternative terms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ammonia is a portion of matter with the chemical formula NH3. It has a gaseous normal state of matter and can act as an air pollutant. As it can be oxidised it can be used as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ammoniak"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "NH3",
@@ -4792,7 +4786,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_16134",
-        rdfs:label "ammonia"@en
+        rdfs:label "ammonia"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
+
+Adapt definition and axioms, add alternative terms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959"
     
     SubClassOf: 
         OEO_00000331,
@@ -4805,8 +4805,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010001
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon monoxide is a portion of matter with the chemical formula CO. It has a gaseous normal state of matter and can act as an air pollutant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kohlenmonoxid"@de,
@@ -4814,7 +4812,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_17245",
-        rdfs:label "carbon monoxide"@en
+        rdfs:label "carbon monoxide"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356"
     
     SubClassOf: 
         OEO_00000331,
@@ -4825,8 +4825,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010002
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen oxides are a portion of matter consisting of compounds of nitrogen and oxygen. It is a collective term for numerous oxides of nitrogen with a gaseous normal state of matter. They can act as air pollutants.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NOx",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Stickoxide"@de,
@@ -4834,7 +4832,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_35196",
-        rdfs:label "nitrogen oxides"@en
+        rdfs:label "nitrogen oxides"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356"
     
     SubClassOf: 
         OEO_00000331,
@@ -4845,14 +4845,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00010003
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitric oxide is a portion of matter with the chemical formula NO. It is a gas and can act as an air pollutant. Synonyms are nitrogen oxide or nitrogen monoxide.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NO",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Stickstoffmonoxid"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen monoxide"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "nitrogen oxide"@en,
-        rdfs:label "nitric oxide"@en
+        rdfs:label "nitric oxide"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356"
     
     SubClassOf: 
         OEO_00010002
@@ -4861,12 +4861,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00010004
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nitrogen dioxide is a portion of matter with the chemical formula NO2. It is a gas and can act as an air pollutant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NO2",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Stickstoffdioxid"@de,
-        rdfs:label "nitrogen dioxide"@en
+        rdfs:label "nitrogen dioxide"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356"
     
     SubClassOf: 
         OEO_00010002
@@ -4875,13 +4875,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00010007
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sulphur dioxide is a portion of matter with the chemical formula SO2. It has a gaseous normal state of matter and can act as an air pollutant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "SO2",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Schwefeldioxid"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "sulfur dioxide"@en,
-        rdfs:label "sulphur dioxide"@en
+        rdfs:label "sulphur dioxide"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356"
     
     SubClassOf: 
         OEO_00000331,
@@ -4892,8 +4892,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
 Class: OEO_00010009
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "PM10 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM10, EN 12341, with a 50 % efficiency cut-off at 10 µm aerodynamic diameter.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         rdfs:label "PM10"@en,
@@ -4904,7 +4902,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000405>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000405>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356"
     
     SubClassOf: 
         OEO_00000318
@@ -4913,8 +4913,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00010010
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "PM2.5 is particulate matter which passes through a size-selective inlet as defined in the reference method for the sampling and measurement of PM2,5, EN 14907, with a 50 % efficiency cut-off at 2,5 µm aerodynamic diameter.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "This definition is partly based on Article 2 of the European Air Quality Directive (2008/50/EC): https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32008L0050",
         rdfs:label "PM2.5"@en,
@@ -4925,7 +4923,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000415>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000415>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356"
     
     SubClassOf: 
         OEO_00000318
@@ -4934,6 +4934,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00010011
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Flüchtigkeit"@de,
+        rdfs:label "volatility"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
 
@@ -4943,10 +4946,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The volatility disposition is the disposition of a portion of matter to sublimate or evaporate from the solid or liquid form and enter the surrounding air.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Flüchtigkeit"@de,
-        rdfs:label "volatility"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
@@ -4956,14 +4956,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00010012
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that participates in some air pollution.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Luftschadstoff"@de,
+        rdfs:label "air pollutant"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/263
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/356
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/815
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/816",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An air pollutant is a portion of matter that participates in some air pollution.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Luftschadstoff"@de,
-        rdfs:label "air pollutant"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/816"
     
     EquivalentTo: 
         OEO_00000331
@@ -4976,11 +4976,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/816",
 Class: OEO_00010015
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil hydrogen is hydrogen with fossil origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fossiler Wasserstoff"@de,
-        rdfs:label "fossil hydrogen"@en
+        rdfs:label "fossil hydrogen"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411"
     
     EquivalentTo: 
         
@@ -4996,15 +4996,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
 Class: OEO_00010016
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetischer Wasserstoff"@de,
+        rdfs:label "synthetic hydrogen"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
 
 shorten definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic hydrogen is hydrogen with synthetic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetischer Wasserstoff"@de,
-        rdfs:label "synthetic hydrogen"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442"
     
     EquivalentTo: 
         
@@ -5020,17 +5020,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
 Class: OEO_00010017
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetischer Brennstoff"@de,
+        rdfs:label "synthetic fuel"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
 
 add axiom to secondary energy carrier disposition
 issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A synthetic fuel is a fuel produced from one or more portion(s) of matter using electric energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "e-fuel"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electric fuel"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetischer Brennstoff"@de,
-        rdfs:label "synthetic fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"
     
     EquivalentTo: 
         OEO_00000173
@@ -5049,19 +5049,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1201"
 Class: OEO_00010018
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
-
-Re-definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic methane is methane that has a synthetic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "P2G"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "PtG"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "synthetisches Methan"@de,
-        rdfs:label "synthetic methane"@en
+        rdfs:label "synthetic methane"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
+
+Re-definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
     
     EquivalentTo: 
         OEO_00000025
@@ -5074,17 +5074,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010019
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "PtL fuel is a liquid synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "liquid synthetic fuel",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetic liquid fuel",
+        rdfs:label "PtL fuel"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
 
 new label and axioms:
 https://github.com/OpenEnergyPlatform/ontology/issues/934
-pull request: https://github.com/OpenEnergyPlatform/ontology/pulls/957",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "PtL fuel is a liquid synthetic fuel produced in a power-to-liquid system from water and carbon dioxide using electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "liquid synthetic fuel",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetic liquid fuel",
-        rdfs:label "PtL fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pulls/957"
     
     SubClassOf: 
         OEO_00010156,
@@ -5095,6 +5095,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pulls/957",
 Class: OEO_00010020
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid system is a power-to-fuel system that implements a power-to-liquid process. A water electrolyser is participating in the power-to-liquid process.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
+        rdfs:label "power-to-liquid system"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
 
@@ -5104,11 +5108,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348
 
 created new parent class 'power-to-fuel system'
 https://github.com/OpenEnergyPlatform/ontology/issues/1477
-https://github.com/OpenEnergyPlatform/ontology/pull/1483",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid system is a power-to-fuel system that implements a power-to-liquid process. A water electrolyser is participating in the power-to-liquid process.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2L",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtL",
-        rdfs:label "power-to-liquid system"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1483"
     
     SubClassOf: 
         OEO_00330009,
@@ -5118,6 +5118,9 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00010021
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting component that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserelektrolyseur"@de,
+        rdfs:label "water electrolyser"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
 
@@ -5126,13 +5129,14 @@ https://github.com/OpenEnergyPlatform/ontology/pull/993
 
 change produces energy and uses energy axioms to 'has energy output' and 'has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolyser is an energy converting component that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserelektrolyseur"@de,
-        rdfs:label "water electrolyser"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00000011,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
+        <http://purl.obolibrary.org/obo/RO_0003000> some OEO_00000220,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
@@ -5144,40 +5148,47 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000007,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0003000> some OEO_00000220
+        OEO_00010235 some OEO_00000007
     
     
 Class: OEO_00010022
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting component that produces syngas from hydrocarbons such as natural gas.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Dampfreformer"@de,
+        rdfs:label "steam reformer"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/134
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/411
 
 use energy converting component in definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/993",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reformer is an energy converting component that produces syngas from hydrocarbons such as natural gas.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Dampfreformer"@de,
-        rdfs:label "steam reformer"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/993"
     
     SubClassOf: 
         OEO_00000011,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
-        OEO_00000503 some OEO_00140159,
+        <http://purl.obolibrary.org/obo/RO_0003000> some OEO_00140160,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805"
-        <http://purl.obolibrary.org/obo/RO_0003000> some OEO_00140160
+        OEO_00000503 some OEO_00140159
     
     
 Class: OEO_00010023
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Fahrzeug"@de,
+        rdfs:label "vehicle"@en,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000604>,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/431
 
@@ -5190,28 +5201,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle is an artificial object that is used for transporting people or goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Fahrzeug"@de,
-        rdfs:label "vehicle"@en,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
-
-Convert to skos:closeMatch
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000604>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000061,
-        OEO_00010235 some OEO_00010114,
-        <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00320041
+        <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00320041,
+        OEO_00010235 some OEO_00010114
     
     
 Class: OEO_00010024
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric vehicle (BEV) is an electric vehicle that stores energy in a traction battery.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "BEV"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "batterieelektrisches Fahrzeug"@de,
+        rdfs:label "battery electric vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
 
@@ -5220,11 +5224,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/655
 
 Adapt definition and convert to equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric vehicle (BEV) is an electric vehicle that stores energy in a traction battery.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "BEV"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "batterieelektrisches Fahrzeug"@de,
-        rdfs:label "battery electric vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"
     
     EquivalentTo: 
         OEO_00000146
@@ -5237,6 +5237,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
 Class: OEO_00010025
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric vehicle (FCEV) is an electric vehicle that uses electrical energy from a fuel cell.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstoffzellenfahrzeug"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV"@en,
+        rdfs:label "fuel cell electric vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
 
@@ -5249,11 +5253,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315
 
 Add fuel tank axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric vehicle (FCEV) is an electric vehicle that uses electrical energy from a fuel cell.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstoffzellenfahrzeug"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "FCEV"@en,
-        rdfs:label "fuel cell electric vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356"
     
     EquivalentTo: 
         OEO_00000146
@@ -5261,19 +5261,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
     
     SubClassOf: 
         OEO_00000146,
-        OEO_00000503 some OEO_00000220,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320056
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320056,
+        OEO_00000503 some OEO_00000220
     
     
 Class: OEO_00010026
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A traction battery is a battery that is used in vehicles for propulsion.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Antriebsbatterie"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Traktionsbatterie"@de,
-        rdfs:label "traction battery"@en
+        rdfs:label "traction battery"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453"
     
     SubClassOf: 
         OEO_00000068
@@ -5282,6 +5282,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453",
 Class: OEO_00010027
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric motor is a motor that converts electrical energy into kinetic energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Elektromotor"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "elektrischer Motor"@de,
+        rdfs:label "electric motor"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
 
@@ -5290,11 +5294,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
 
 change uses energy axiom to 'has energy input':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric motor is a motor that converts electrical energy into kinetic energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Elektromotor"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "elektrischer Motor"@de,
-        rdfs:label "electric motor"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00010032,
@@ -5304,15 +5304,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
 Class: OEO_00010028
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric traction motor is an electric motor used for propulsion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "elektrischer Antriebsmotor"@de,
+        rdfs:label "electric traction motor"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
 
 relabel and add axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1029
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electric traction motor is an electric motor used for propulsion."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "elektrischer Antriebsmotor"@de,
-        rdfs:label "electric traction motor"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135"
     
     SubClassOf: 
         OEO_00010027,
@@ -5322,6 +5322,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
 Class: OEO_00010029
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion engine is a motor that converts chemical energy into kinetic energy using a cyclic combustion process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Verbrennungsmotor"@de,
+        rdfs:label "internal combustion engine"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
 
@@ -5330,24 +5333,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
 
 add energy input axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1280
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1285",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An internal combustion engine is a motor that converts chemical energy into kinetic energy using a cyclic combustion process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Verbrennungsmotor"@de,
-        rdfs:label "internal combustion engine"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1285"
     
     SubClassOf: 
         OEO_00010032,
-        OEO_00000503 some OEO_00000099,
-        OEO_00010234 some OEO_00000007,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140038
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140038,
+        OEO_00000503 some OEO_00000099,
+        OEO_00010234 some OEO_00000007
     
     
 Class: OEO_00010030
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both an electric traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Plug-in-Hybrid-Fahrzeug"@de,
+        rdfs:label "plug-in hybrid electric vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
 
@@ -5357,11 +5361,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315
 
 Add fuel tank axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric vehicle (PHEV) is a vehicle that contains both an electric traction motor and an internal combustion engine and can switch between their usage for propulsion. It contains a traction battery that can be charged with electrical energy from an external supply.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PHEV"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Plug-in-Hybrid-Fahrzeug"@de,
-        rdfs:label "plug-in hybrid electric vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356"
     
     EquivalentTo: 
         OEO_00010023
@@ -5372,23 +5372,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
     
     SubClassOf: 
         OEO_00010023,
-        OEO_00000503 some OEO_00000099,
-        OEO_00000503 some OEO_00000139,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010026,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320056
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320056,
+        OEO_00000503 some OEO_00000099,
+        OEO_00000503 some OEO_00000139
     
     
 Class: OEO_00010031
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid supplied electric vehicle is an electric vehicle that has a current collector to use electrical energy.",
+        rdfs:label "grid supplied electric vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/425
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/453
 
 Adapt definition and convert to equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid supplied electric vehicle is an electric vehicle that has a current collector to use electrical energy.",
-        rdfs:label "grid supplied electric vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"
     
     EquivalentTo: 
         OEO_00000146
@@ -5401,6 +5401,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
 Class: OEO_00010032
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A motor is an energy converting component that converts other forms of energy into kinetic energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Motor"@de,
+        rdfs:label "motor"@en,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000610>,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817
 
@@ -5412,18 +5423,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/993
 
 change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A motor is an energy converting component that converts other forms of energy into kinetic energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Motor"@de,
-        rdfs:label "motor"@en,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
-
-Convert to skos:closeMatch
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000610>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00000011,
@@ -5436,11 +5436,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010072
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density unit is a unit which is a measure for the power per surface area.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Flächenleistungsdichte Einheit"@de,
-        rdfs:label "areal power density unit"@en
+        rdfs:label "areal power density unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000000>
@@ -5449,11 +5449,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010073
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density unit is a unit which is a measure for the energy per surface area.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Flächenenergiedichte Einheit"@de,
-        rdfs:label "areal energy density unit"@en
+        rdfs:label "areal energy density unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000000>
@@ -5462,12 +5462,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010074
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal power density is a quantity value that indicates a certain power per area.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Flächenleistungsdichte"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "specific power"@en,
-        rdfs:label "areal power density"@en
+        rdfs:label "areal power density"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615"
     
     SubClassOf: 
         OEO_00000350,
@@ -5477,11 +5477,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010075
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal energy density is a quantity value that states a certain energy amount per area.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Flächenenergiedichte"@de,
-        rdfs:label "areal energy density"@en
+        rdfs:label "areal energy density"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615"
     
     SubClassOf: 
         OEO_00000350,
@@ -5491,11 +5491,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010076
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar power density is an areal power density that indicates the arriving solar power per area. A synonym for areal solar power density is irradiance.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "irradiance",
-        rdfs:label "areal solar power density"@en
+        rdfs:label "areal solar power density"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615"
     
     SubClassOf: 
         OEO_00010074
@@ -5504,15 +5504,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615",
 Class: OEO_00010077
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar energy density is an areal energy density that gives the arriving solar energy per area. A synonym for areal solar energy density is irradiation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "irradiation",
+        rdfs:label "areal solar energy density"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/597
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/615
 
 correct definition to state 'energy' instead of 'power'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1981
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1983",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An areal solar energy density is an areal energy density that gives the arriving solar energy per area. A synonym for areal solar energy density is irradiation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "irradiation",
-        rdfs:label "areal solar energy density"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1983"
     
     SubClassOf: 
         OEO_00010075
@@ -5521,6 +5521,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1983",
 Class: OEO_00010078
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a quantity value that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of carbon dioxide (CO2).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "GWP"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Treibhauspotenzial"@de,
+        rdfs:label "global warming potential"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/683
 
@@ -5529,11 +5533,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1410
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Global warming potential (GWP) is a quantity value that measures the the time-integrated radiative forcing due to a pulse emission of a given component, relative to a pulse emission of an equal mass of carbon dioxide (CO2).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "GWP"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Treibhauspotenzial"@de,
-        rdfs:label "global warming potential"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000350,
@@ -5543,6 +5543,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010079
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a quantity value that quantifies an emission rate and has a mass unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Emissionswert"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "emission quantity value",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "It can be calculated using the an emission factor.",
+        rdfs:label "emission value"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/695
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/697
 
@@ -5556,12 +5561,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846
 
 Correction of implementing mistake concerning emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission value is a quantity value that quantifies an emission rate and has a mass unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Emissionswert"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "emission quantity value",
-        <http://purl.obolibrary.org/obo/IAO_0000600> "It can be calculated using the an emission factor.",
-        rdfs:label "emission value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880"
     
     SubClassOf: 
         OEO_00000350,
@@ -5572,6 +5572,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
 Class: OEO_00010080
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar-steam-electric process is a solar energy transformation that converts solar energy into electrical energy. It has two partial processes: a solar thermal energy transformation and a steam-electric process."@en,
+        rdfs:label "solar-steam-electric process"@en,
         OEO_00020426 "add two has participant and redefine
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/938
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
@@ -5585,9 +5587,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/701
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar-steam-electric process is a solar energy transformation that converts solar energy into electrical energy. It has two partial processes: a solar thermal energy transformation and a steam-electric process."@en,
-        rdfs:label "solar-steam-electric process"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"
     
     EquivalentTo: 
         (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020047)
@@ -5595,23 +5595,23 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
     
     SubClassOf: 
         OEO_00020046,
-        OEO_00010235 some OEO_00000139,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396,
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00010081
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar chemical energy transformation is a solar energy transformation that converts solar energy into chemical energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "solarchemische Energieumwandlung"@de,
+        rdfs:label "solar chemical energy transformation"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/673
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/735
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar chemical energy transformation is a solar energy transformation that converts solar energy into chemical energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "solarchemische Energieumwandlung"@de,
-        rdfs:label "solar chemical energy transformation"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"
     
     SubClassOf: 
         OEO_00020046,
@@ -5621,78 +5621,78 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00010084
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir is an artificial object that stores liquid water and has a dam as part.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Reservoirs created by dams provide water for activities such as hydro energy transformation, irrigation, human consumption, industrial use, aquaculture, and navigability. They are also used to regulate floods.",
-        rdfs:label "reservoir"@en
+        rdfs:label "reservoir"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/681
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/755"
     
     SubClassOf: 
         OEO_00000061,
-        OEO_00000503 some OEO_00110000,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117,
+        OEO_00000503 some OEO_00110000
     
     
 Class: OEO_00010085
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power unit is a power generating unit that uses hydro energy.",
-        rdfs:label "hydro power unit"@en
+        rdfs:label "hydro power unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758"
     
     SubClassOf: 
         OEO_00000334,
-        OEO_00000503 some OEO_00000441,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000442,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110005
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110005,
+        OEO_00000503 some OEO_00000441
     
     
 Class: OEO_00010086
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power plant is a power plant having an aggregate of hydro power generating units as its power generating unit parts.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserkraftwerk"@de,
-        rdfs:label "hydro power plant"@en
+        rdfs:label "hydro power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758"
     
     SubClassOf: 
         OEO_00000031,
-        OEO_00000503 some OEO_00000441,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010085,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110005
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00110005,
+        OEO_00000503 some OEO_00000441
     
     
 Class: OEO_00010087
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A run of river power plant is a hydro power plant that uses the momentarily available hydro energy of a river. It has either no reservoir or just has a small one with a maximum of 24 hours of storage.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Laufwasserkraftwerk"@de,
-        rdfs:label "run of river power plant"@en
+        rdfs:label "run of river power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758"
     
     SubClassOf: 
         OEO_00010086,
-        OEO_00000503 some OEO_00010093,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000117,
+        OEO_00000503 some OEO_00010093
     
     
 Class: OEO_00010088
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro storage power plant is a hydro power plant that uses the available hydro energy of a stationary water storage.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "The distinction between a run of river power plant and a hydro storage power plant is important for modelling, but in reality not so easy. The chosen distinction follows the document: European Network of Transmission System Operators for Electricity (ENTSO-E): Hydropower modelling – New database complementing PECD, V.1.0, 12 December 2019, https://www.entsoe.eu/Documents/SDC%20documents/MAF/2019/Hydropower_Modelling_New_database_and_methodology.pdf",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Speicherwasserkraftwerk"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "storage power plant"@en,
-        rdfs:label "hydro storage power plant"@en
+        rdfs:label "hydro storage power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758"
     
     SubClassOf: 
         OEO_00010086,
@@ -5704,15 +5704,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010089
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Pumpspeicherkraftwerk"@de,
+        rdfs:label "pumped hydro storage power plant"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
 
 Add energy storage function axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1174
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power plant is a hydro storage power plant which has some pumps as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Pumpspeicherkraftwerk"@de,
-        rdfs:label "pumped hydro storage power plant"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348"
     
     SubClassOf: 
         OEO_00010088,
@@ -5723,6 +5723,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00010090
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting component that converts energy into kinetic or potential energy of a fluid.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Pumpe"@de,
+        rdfs:label "pump"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758
 
@@ -5731,10 +5734,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/993
 
 change produces energy axiom to 'has energy output':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pump is an energy converting component that converts energy into kinetic or potential energy of a fluid.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Pumpe"@de,
-        rdfs:label "pump"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
     SubClassOf: 
         OEO_00000011,
@@ -5752,10 +5752,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
 Class: OEO_00010091
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An open-loop pumped hydro storage power plant is a pumped hydro storage power plant that has natural inflows.",
-        rdfs:label "open-loop pumped hydro storage power plant"@en
+        rdfs:label "open-loop pumped hydro storage power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758"
     
     SubClassOf: 
         OEO_00010089,
@@ -5765,10 +5765,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010092
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A closed-loop pumped hydro storage power plant is a pumped hydro storage power plant that has no natural inflows.",
-        rdfs:label "closed-loop pumped hydro storage power plant"@en
+        rdfs:label "closed-loop pumped hydro storage power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/78
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758"
     
     SubClassOf: 
         OEO_00010089,
@@ -5778,6 +5778,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/758",
 Class: OEO_00010093
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A river is a water body that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Fluss"@de,
+        rdfs:label "river"@en,
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00000022>,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/760
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/765
 
@@ -5787,11 +5791,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A river is a water body that moves through permanent or seasonal flow process from elevated land towards lower elevations through a definite channel and empties either into a sea, lake, or another river or ends on land as bed seepage and evapotranspiration exceed water supply.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Fluss"@de,
-        rdfs:label "river"@en,
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00000022>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
     
     SubClassOf: 
         OEO_00010104,
@@ -5801,10 +5801,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
 Class: OEO_00010094
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issue/767
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir hydro storage power plant is a hydro storage power plant that has no pump.",
-        rdfs:label "reservoir hydro storage power plant"@en
+        rdfs:label "reservoir hydro storage power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issue/767
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768"
     
     SubClassOf: 
         OEO_00010088,
@@ -5814,10 +5814,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/768",
 Class: OEO_00010095
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy is a kind of natural ambient thermal energy that is present in marine water bodies.",
-        rdfs:label "marine thermal energy"@en
+        rdfs:label "marine thermal energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806"
     
     SubClassOf: 
         OEO_00140104
@@ -5826,10 +5826,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010096
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Marine thermal energy transfer is a heat transfer from the marine water body to a transportable material entity.",
-        rdfs:label "marine thermal energy transfer"@en
+        rdfs:label "marine thermal energy transfer"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806"
     
     SubClassOf: 
         OEO_00140101,
@@ -5839,6 +5839,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010097
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the natural hydro energy of an ocean current.",
+        rdfs:label "marine current energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 
@@ -5847,9 +5849,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
 
 add and change axioms
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy is the natural hydro energy of an ocean current.",
-        rdfs:label "marine current energy"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
     
     SubClassOf: 
         OEO_00020087,
@@ -5864,6 +5864,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
 Class: OEO_00010098
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy transformation is a hydroelectric energy transformation that converts marine current energy to electrical energy.",
+        rdfs:label "marine current energy transformation"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 
@@ -5871,13 +5873,10 @@ change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
 https://github.com/OpenEnergyPlatform/ontology/pull/1041
 remove wrong axiom 
-https://github.com/OpenEnergyPlatform/ontology/pull/1044",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine current energy transformation is a hydroelectric energy transformation that converts marine current energy to electrical energy.",
-        rdfs:label "marine current energy transformation"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1044"
     
     SubClassOf: 
         OEO_00110005,
-        OEO_00010234 some OEO_00010097,
         
             Annotations: rdfs:comment "reintroduce axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
@@ -5887,35 +5886,38 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
             Annotations: OEO_00020426 "replace 'has input' with 'causally downstream of or within'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010107
+        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010107,
+        OEO_00010234 some OEO_00010097
     
     
 Class: OEO_00010099
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy transformation is a hydroelectric energy transformation that converts kinetic energy from tidal flow to electrical energy.",
+        rdfs:label "marine tidal energy transformation"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy transformation is a hydroelectric energy transformation that converts kinetic energy from tidal flow to electrical energy.",
-        rdfs:label "marine tidal energy transformation"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"
     
     SubClassOf: 
         OEO_00110005,
-        OEO_00010234 some OEO_00010100,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         
             Annotations: OEO_00020426 "replace 'has input' with 'causally downstream of or within'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010101
+        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010101,
+        OEO_00010234 some OEO_00010100
     
     
 Class: OEO_00010100
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy is the natural hydro energy of a tidal flow.",
+        rdfs:label "marine tidal energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 
@@ -5924,9 +5926,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
 
 change axiom from participates in to is energy participant of
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine tidal energy is the natural hydro energy of a tidal flow.",
-        rdfs:label "marine tidal energy"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
     
     SubClassOf: 
         OEO_00020087,
@@ -5936,16 +5936,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
 Class: OEO_00010101
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Gezeitenströmung"@de,
+        rdfs:label "tidal flow"@en,
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001342>,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Tidal flow is a water flow during which movements of water masses caused by varying gravitational and rotational forces from sun and moon, combined with the rotation of the earth, cause waters to undergo periodic depth oscillations (tides).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Gezeitenströmung"@de,
-        rdfs:label "tidal flow"@en,
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001342>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
     
     SubClassOf: 
         OEO_00110002
@@ -5954,6 +5954,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
 Class: OEO_00010102
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy is the natural hydro energy of a wave.",
+        rdfs:label "marine wave energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 
@@ -5962,9 +5964,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
 
 change axiom from participates in to is energy participant of
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy is the natural hydro energy of a wave.",
-        rdfs:label "marine wave energy"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
     
     SubClassOf: 
         OEO_00020087,
@@ -5978,34 +5978,34 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
 Class: OEO_00010103
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy transformation is a hydroelectric energy transformation that converts marine wave energy to electrical energy.",
+        rdfs:label "marine wave energy transformation"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Marine wave energy transformation is a hydroelectric energy transformation that converts marine wave energy to electrical energy.",
-        rdfs:label "marine wave energy transformation"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"
     
     SubClassOf: 
         OEO_00110005,
-        OEO_00010234 some OEO_00010102,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         
             Annotations: OEO_00020426 "replace 'has input' with 'causally downstream of or within'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010106
+        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010106,
+        OEO_00010234 some OEO_00010102
     
     
 Class: OEO_00010104
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A water body is an accumulation of liquid water of varying size on the surface of the Earth.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gewässer"@de,
-        rdfs:label "water body"@en
+        rdfs:label "water body"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806"
     
     SubClassOf: 
         OEO_00110000
@@ -6014,13 +6014,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010105
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The ocean is a water body that consists of salt water and is covering approximately 71% of Earth's surface.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ozean"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "marine water body"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "sea"@en,
-        rdfs:label "ocean"@en
+        rdfs:label "ocean"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806"
     
     SubClassOf: 
         OEO_00010104
@@ -6029,11 +6029,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010106
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wave is a water flow that is at the surface of a water body/marine water body/ocean and that is mainly vertically orientated.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Welle"@de,
-        rdfs:label "wave"@en
+        rdfs:label "wave"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806"
     
     SubClassOf: 
         OEO_00110002
@@ -6042,11 +6042,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010107
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An ocean current is a a water flow within a water body/marine water body/ocean that is mainly horizontally orientated.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ozeanströmung"@de,
-        rdfs:label "ocean current"@en
+        rdfs:label "ocean current"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806"
     
     SubClassOf: 
         OEO_00110002
@@ -6055,6 +6055,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010108
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy converting unit is a hydro power unit that uses marine current energy.",
+        rdfs:label "marine current energy converting unit"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 
@@ -6064,20 +6066,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
 
 Add function:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy converting unit is a hydro power unit that uses marine current energy.",
-        rdfs:label "marine current energy converting unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437"
     
     SubClassOf: 
         OEO_00010085,
-        OEO_00010234 some OEO_00010097,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010098,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388,
+        OEO_00010234 some OEO_00010097
     
     
 Class: OEO_00010109
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy converting unit is a hydro power unit that uses marine tidal energy.",
+        rdfs:label "marine tidal energy converting unit"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 
@@ -6087,20 +6089,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
 
 Add function:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy converting unit is a hydro power unit that uses marine tidal energy.",
-        rdfs:label "marine tidal energy converting unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437"
     
     SubClassOf: 
         OEO_00010085,
-        OEO_00010234 some OEO_00010100,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010099,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388,
+        OEO_00010234 some OEO_00010100
     
     
 Class: OEO_00010110
 
     Annotations: 
+        rdfs:label "marine wave energy converting unit"@en,
         OEO_00020426 "A marine wave energy converting unit is a hydro power unit that uses marine wave energy.",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
@@ -6111,24 +6112,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
 
 Add function:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437",
-        rdfs:label "marine wave energy converting unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437"
     
     SubClassOf: 
         OEO_00010085,
-        OEO_00010234 some OEO_00010102,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010103,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010388,
+        OEO_00010234 some OEO_00010102
     
     
 Class: OEO_00010111
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy power plant is a power plant that has marine current energy units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Meeresströmungskraftwerk"@de,
-        rdfs:label "marine current energy power plant"@en
+        rdfs:label "marine current energy power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806"
     
     SubClassOf: 
         OEO_00010086,
@@ -6139,10 +6139,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010112
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy power plant is a power plant that has marine tidal energy units as parts.",
-        rdfs:label "marine tidal energy power plant"@en
+        rdfs:label "marine tidal energy power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806"
     
     SubClassOf: 
         OEO_00010086,
@@ -6153,11 +6153,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010113
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine wave energy power plant is a power plant that has marine wave energy units as parts.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wellenkraftwerk"@de,
-        rdfs:label "marine wave energy power plant"@en
+        rdfs:label "marine wave energy power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806"
     
     SubClassOf: 
         OEO_00010086,
@@ -6168,6 +6168,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806",
 Class: OEO_00010114
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Abwärme"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat"@en,
+        rdfs:label "waste thermal energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/775
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/813
 
@@ -6180,11 +6184,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Waste thermal energy is thermal energy that is the physical output of an energy transformation process and that is released into the environment unused."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Abwärme"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "waste heat"@en,
-        rdfs:label "waste thermal energy"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000207
@@ -6199,6 +6199,9 @@ Class: OEO_00010117
 Class: OEO_00010127
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy production is the production of secondary energy carriers.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "secondary production of energy",
+        rdfs:label "secondary energy production"@en,
         OEO_00020426 "add alternative term:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
 pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
@@ -6216,10 +6219,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1619
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy production is the production of secondary energy carriers.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "secondary production of energy",
-        rdfs:label "secondary energy production"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00240003
@@ -6227,21 +6227,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
     
     SubClassOf: 
         OEO_00240003,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020003,
         OEO_00000533 some OEO_00140079,
-        OEO_00140002 some OEO_00050019,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020003
+        OEO_00140002 some OEO_00050019
     
     
 Class: OEO_00010137
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/856
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/879",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Metric ton (t) is a a mass unit which is equal to thousand of a kilogram or 10^3 kg.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "metrische Tonne"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "tonne"@en,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "t",
-        rdfs:label "metric ton"@en
+        rdfs:label "metric ton"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/856
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/879"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000002>
@@ -6250,11 +6250,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/879",
 Class: OEO_00010138
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture is a process that captures carbon dioxide from a gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2-Abscheidung"@de,
-        rdfs:label "carbon capture"@en
+        rdfs:label "carbon capture"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -6264,11 +6264,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010139
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Direct air capture (DAC) is carbon dioxide capture from air.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "DAC",
-        rdfs:label "direct air capture"@en
+        rdfs:label "direct air capture"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911"
     
     SubClassOf: 
         OEO_00010138,
@@ -6278,12 +6278,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010140
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon storage is a process that stores CO2 in a geological formation.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2-Speicherung"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "carbon sequestration"@en,
-        rdfs:label "carbon storage"@en
+        rdfs:label "carbon storage"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -6293,13 +6293,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010141
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Carbon capture and storage (CCS) is a process that combines carbon capture and carbon sequestration.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CCS"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "CCS"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "carbon capture and sequestration"@en,
-        rdfs:label "carbon capture and storage"@en
+        rdfs:label "carbon capture and storage"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/863
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911"
     
     EquivalentTo: 
         (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010138)
@@ -6313,10 +6313,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/911",
 Class: OEO_00010144
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid combustion fuel is a combustion fuel that has a solid state of matter under normal conditions.",
-        rdfs:label "solid combustion fuel"@en
+        rdfs:label "solid combustion fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00000099
@@ -6329,11 +6329,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010145
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid combustion fuel is a combustion fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "biogener Brennstoff"@de,
-        rdfs:label "liquid combustion fuel"@en
+        rdfs:label "liquid combustion fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00000099
@@ -6346,11 +6346,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010146
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous combustion fuel is a combustion fuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "gasförmiger Brennstoff"@de,
-        rdfs:label "gaseous combustion fuel"@en
+        rdfs:label "gaseous combustion fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00000099
@@ -6363,11 +6363,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010147
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid fossil fuel is a fossil combustion fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fossiler Flüssigkraftstoff"@de,
-        rdfs:label "liquid fossil fuel"@en
+        rdfs:label "liquid fossil fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00000014
@@ -6380,11 +6380,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010148
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous fossil fuel is a fossil combustion fuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "gasförmiger fossiler Brennstoff"@de,
-        rdfs:label "gaseous fossil fuel"@en
+        rdfs:label "gaseous fossil fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00000014
@@ -6397,10 +6397,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010149
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solid renewable fuel is a renewable fuel that has a solid state of matter under normal conditions.",
-        rdfs:label "solid renewable fuel"@en
+        rdfs:label "solid renewable fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00000033
@@ -6413,11 +6413,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010150
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid renewable fuel is a renewable fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbarer Flüssigkraftstoff"@de,
-        rdfs:label "liquid renewable fuel"@en
+        rdfs:label "liquid renewable fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00000033
@@ -6430,11 +6430,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010151
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gaseous renewable fuel is a renewable fuel that has a gaseous state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "gasförmiger erneuerbarer Brennstoff"@de,
-        rdfs:label "gaseous renewable fuel"@en
+        rdfs:label "gaseous renewable fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00000033
@@ -6447,11 +6447,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010153
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gasförmiger biogener Brennstoff"@de,
+        rdfs:label "gaseous biofuel"@en,
         OEO_00020426 "A gaseous biofuel is a biofuel that has a gaseous state of matter under normal conditions.",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "gasförmiger biogener Brennstoff"@de,
-        rdfs:label "gaseous biofuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00000072
@@ -6464,10 +6464,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010154
 
     Annotations: 
+        rdfs:label "solid synthetic fuel"@en,
         OEO_00020426 "A solid synthetic fuel is a synthetic fuel that has a solid state of matter under normal conditions.",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        rdfs:label "solid synthetic fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00010017
@@ -6480,11 +6480,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010155
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gasförmiger synthetischer Brennstoff"@de,
+        rdfs:label "gaseous synthetic fuel"@en,
         OEO_00020426 "A gaseous synthetic fuel is a synthetic fuel that has a gaseous state of matter under normal conditions.",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "gasförmiger synthetischer Brennstoff"@de,
-        rdfs:label "gaseous synthetic fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00010017
@@ -6497,11 +6497,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010156
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquid synthetic fuel is a synthetic fuel that has a liquid state of matter under normal conditions.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "synthetischer Flüssigkraftstoff"@de,
-        rdfs:label "liquid synthetic fuel"@en
+        rdfs:label "liquid synthetic fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/811
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931"
     
     EquivalentTo: 
         OEO_00010017
@@ -6514,14 +6514,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/931",
 Class: OEO_00010157
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power value is a quantity value that has a power unit as unit.",
+        rdfs:label "power value"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/918
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
 
 Make equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power value is a quantity value that has a power unit as unit.",
-        rdfs:label "power value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155"
     
     EquivalentTo: 
         OEO_00000350
@@ -6534,6 +6534,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00010210
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Energieverbrauch"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy consumption"@en,
+        rdfs:label "energy use"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950
 
@@ -6545,11 +6549,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1463
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy use is the consumption of an energy carrier making use of the energy it carries.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Energieverbrauch"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy consumption"@en,
-        rdfs:label "energy use"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00140039,
@@ -6562,6 +6562,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010211
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "nichtenergetischer Verbrauch"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "non-energy consumption"@en,
+        rdfs:label "non-energy use"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/718
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/950
 
@@ -6578,11 +6582,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 Add alternative label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1803",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Non-energy use is the consumption of an energy carrier without making use the energy it carries.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "nichtenergetischer Verbrauch"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "non-energy consumption"@en,
-        rdfs:label "non-energy use"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1803"
     
     SubClassOf: 
         OEO_00140039,
@@ -6595,11 +6595,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1803",
 Class: OEO_00010214
 
     Annotations: 
-        OEO_00020426 "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Biomass is a portion of matter from plants or animals and has thus has a biogenic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Biomasse"@de,
-        rdfs:label "biomass"@en
+        rdfs:label "biomass"@en,
+        OEO_00020426 "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952"
     
     SubClassOf: 
         OEO_00000331,
@@ -6609,28 +6609,35 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952",
 Class: OEO_00010215
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomethane is a gas mixture produced from biogas by removing carbon dioxide. It consists mainly of methane and can be used as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Biomethan"@de,
+        rdfs:label "biomethane"@en,
         OEO_00020426 "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
 
 improve definition and make subclass of gas mixture:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biomethane is a gas mixture produced from biogas by removing carbon dioxide. It consists mainly of methane and can be used as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Biomethan"@de,
-        rdfs:label "biomethane"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009"
     
     SubClassOf: 
         OEO_00010236,
-        OEO_00000530 some OEO_00030001,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000025,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000530 some OEO_00030001,
         OEO_00000529 value OEO_00000182
     
     
 Class: OEO_00010216
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas process is a power-to-fuel process that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Power-to-Gas-Prozess"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas"@en,
+        rdfs:label "power-to-gas process"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
 
@@ -6640,14 +6647,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041
 
 changed to subclass of  newly added 'power-to-fuel process'
 https://github.com/OpenEnergyPlatform/ontology/issues/1477
-https://github.com/OpenEnergyPlatform/ontology/pull/1483",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas process is a power-to-fuel process that converts electrical energy to chemical energy by synthesising portions of matter into a gaseous synthetic fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "P2G"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Power-to-Gas-Prozess"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "PtG"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to gas"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-gas"@en,
-        rdfs:label "power-to-gas process"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1483"
     
     SubClassOf: 
         OEO_00330007,
@@ -6660,6 +6660,10 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00010217
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy as energy input, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Power-to-Methane-Prozess"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to methane"@en,
+        rdfs:label "power-to-methane process"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
 
@@ -6669,11 +6673,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041
 
 added new parent class `power-to-fuel proces' upstream
 https://github.com/OpenEnergyPlatform/ontology/issues/1477
-https://github.com/OpenEnergyPlatform/ontology/pull/1483",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane process is a power-to-gas process that has electrical energy as energy input, water and carbon dioxide as physical input and synthetic methane carrying chemical energy as physical output. It consists of two sub processes: an electrolysis process and a methanation.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Power-to-Methane-Prozess"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to methane"@en,
-        rdfs:label "power-to-methane process"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1483"
     
     SubClassOf: 
         OEO_00010216,
@@ -6689,12 +6689,12 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00010218
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Oxygen is a portion of matter with the chemical formula O2. It has a gaseous normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "O2",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Sauerstoff"@de,
-        rdfs:label "oxygen"@en
+        rdfs:label "oxygen"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
     
     SubClassOf: 
         OEO_00000331,
@@ -6704,15 +6704,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010219
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserelektrolyse"@de,
+        rdfs:label "water electrolysis process"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A water electrolysis process is an energy transformation that uses an electric current to decompose water into hydrogen and oxygen gas. Electrical energy is converted into chemical energy (and waste heat).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserelektrolyse"@de,
-        rdfs:label "water electrolysis process"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"
     
     SubClassOf: 
         OEO_00020003,
@@ -6727,11 +6727,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00010220
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A methanation is a redox reaction that converts carbon dioxide and hydrogen to synthetic methane and water.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Methanisierung"@de,
-        rdfs:label "methanation"@en
+        rdfs:label "methanation"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/940
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954"
     
     SubClassOf: 
         OEO_00140034,
@@ -6744,11 +6744,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/954",
 Class: OEO_00010221
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic ammonia is ammonia that has a synthetic origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "synthetisches Ammoniak"@de,
-        rdfs:label "synthetic ammonia"@en
+        rdfs:label "synthetic ammonia"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959"
     
     EquivalentTo: 
         OEO_00010000
@@ -6761,15 +6761,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959",
 Class: OEO_00010222
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "power to ammonia",
+        rdfs:label "power-to-ammonia process"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/939
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/959
 
 added new parent class `power-to-fuel proces' upstream
 https://github.com/OpenEnergyPlatform/ontology/issues/1477
-https://github.com/OpenEnergyPlatform/ontology/pull/1483",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia process is a power-to-gas process that has ammonia as output.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "power to ammonia",
-        rdfs:label "power-to-ammonia process"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1483"
     
     SubClassOf: 
         OEO_00010216,
@@ -6779,15 +6779,15 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00010223
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic waste fuel is a waste fuel that has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable waste fuel",
+        rdfs:label "biogenic waste fuel"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
 
 rename class and change axiom:
 https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic waste fuel is a waste fuel that has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable waste fuel",
-        rdfs:label "biogenic waste fuel"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1048"
     
     EquivalentTo: 
         OEO_00000439
@@ -6800,10 +6800,10 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048",
 Class: OEO_00010224
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil waste fuel is a waste fuel that has a fossil origin.",
-        rdfs:label "fossil waste fuel"@en
+        rdfs:label "fossil waste fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961"
     
     EquivalentTo: 
         OEO_00000439
@@ -6816,15 +6816,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00010225
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic industrial waste fuel is an industrial waste fuel that has a biogenic origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable industrial waste fuel",
+        rdfs:label "biogenic industrial waste fuel"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961
 
 rename class and change axiom:
 https://github.com/OpenEnergyPlatform/ontology/issues/872
-https://github.com/OpenEnergyPlatform/ontology/pull/1048",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A biogenic industrial waste fuel is an industrial waste fuel that has a biogenic origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewable industrial waste fuel",
-        rdfs:label "biogenic industrial waste fuel"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1048"
     
     EquivalentTo: 
         OEO_00000226
@@ -6837,10 +6837,10 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048",
 Class: OEO_00010226
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fossil industrial waste fuel is an industrial waste fuel that has a fossil origin.",
-        rdfs:label "fossil industrial waste fuel"@en
+        rdfs:label "fossil industrial waste fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/925
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961"
     
     EquivalentTo: 
         OEO_00000226
@@ -6853,11 +6853,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/961",
 Class: OEO_00010236
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas mixture is a portion of matter that is a composition of different kinds of portions of matter and that has a gaseous normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gasgemisch"@de,
-        rdfs:label "gas mixture"@en
+        rdfs:label "gas mixture"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/988
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009"
     
     SubClassOf: 
         OEO_00000331,
@@ -6867,16 +6867,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009",
 Class: OEO_00010237
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquefied natural gas (LNG) is natural gas that has a liquid state of matter.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Flüssiggas"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "LNG",
+        rdfs:label "liquefied natural gas"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1005
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1016
 
 change spelling from liquified to liquefied:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Liquefied natural gas (LNG) is natural gas that has a liquid state of matter.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Flüssiggas"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "LNG",
-        rdfs:label "liquefied natural gas"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"
     
     EquivalentTo: 
         OEO_00000292
@@ -6889,14 +6889,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290",
 Class: OEO_00010239
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline fuel role is a fuel role that expresses that a portion of matter can be used in a gasoline engine.",
         
             Annotations: OEO_00020426 "https://github.com/OpenEnergyPlatform/ontology/issues/1028
 https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        rdfs:label "gasoline fuel role"@en
+        rdfs:label "gasoline fuel role"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027"
     
     SubClassOf: 
         OEO_00000001
@@ -6908,14 +6908,14 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1037"
 Class: OEO_00010240
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel fuel role is a fuel role that expresses that a portion of matter can be used in a diesel engine.",
+        rdfs:label "diesel fuel role"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
 
 add disjoint axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1286
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel fuel role is a fuel role that expresses that a portion of matter can be used in a diesel engine.",
-        rdfs:label "diesel fuel role"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288"
     
     SubClassOf: 
         OEO_00000001
@@ -6927,14 +6927,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288",
 Class: OEO_00010241
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline fuel is a combustion fuel that has a gasoline fuel role.",
         
             Annotations: OEO_00020426 "https://github.com/OpenEnergyPlatform/ontology/issues/1028
 https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
-        rdfs:label "gasoline fuel"@en
+        rdfs:label "gasoline fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027"
     
     EquivalentTo: 
         OEO_00000099
@@ -6950,15 +6950,15 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1037"
 Class: OEO_00010242
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel fuel is a combustion fuel that has a diesel fuel role.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Dieselkraftstoff"@de,
+        rdfs:label "diesel fuel"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
 
 add disjoint axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1286
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel fuel is a combustion fuel that has a diesel fuel role.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Dieselkraftstoff"@de,
-        rdfs:label "diesel fuel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288"
     
     EquivalentTo: 
         OEO_00000099
@@ -6974,8 +6974,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288",
 Class: OEO_00010243
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline engine is an internal combustion engine that uses a gasoline fuel.",
         
             Annotations: OEO_00020426 "https://github.com/OpenEnergyPlatform/ontology/issues/1028
@@ -6984,7 +6982,9 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000118> "Benzinmotor"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ottomotor"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "gasoline motor"@en,
-        rdfs:label "gasoline engine"@en
+        rdfs:label "gasoline engine"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027"
     
     SubClassOf: 
         OEO_00010029,
@@ -6994,16 +6994,16 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1037"
 Class: OEO_00010244
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel engine is an internal combustion engine that uses a diesel fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Dieselmotor"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "diesel motor",
+        rdfs:label "diesel engine"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
 
 update axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1286
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel engine is an internal combustion engine that uses a diesel fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Dieselmotor"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "diesel motor",
-        rdfs:label "diesel engine"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288"
     
     SubClassOf: 
         OEO_00010029,
@@ -7013,19 +7013,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288",
 Class: OEO_00010245
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
-
-Convert to equivalent class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline vehicle is an internal combustion vehicle that has only a gasoline engine as motor for propulsion.",
         
             Annotations: OEO_00020426 "https://github.com/OpenEnergyPlatform/ontology/issues/1028
 https://github.com/OpenEnergyPlatform/ontology/pull/1037"
         <http://purl.obolibrary.org/obo/IAO_0000116> "The term gasoline was chosen as this term is more often used in energy modelling and energy statistics. This is a deliberate deviation from the convention of British English spelling in the OEO.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Benzinfahrzeug"@de,
-        rdfs:label "gasoline vehicle"@en
+        rdfs:label "gasoline vehicle"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
+
+Convert to equivalent class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"
     
     EquivalentTo: 
         OEO_00000240
@@ -7041,6 +7041,9 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1037"
 Class: OEO_00010246
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel vehicle is an internal combustion vehicle that has only a diesel engine as motor for propulsion.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Dieselfahrzeug"@de,
+        rdfs:label "diesel vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/960
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1027
 
@@ -7050,10 +7053,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1288
 
 Convert to equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel vehicle is an internal combustion vehicle that has only a diesel engine as motor for propulsion.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Dieselfahrzeug"@de,
-        rdfs:label "diesel vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"
     
     EquivalentTo: 
         OEO_00000240
@@ -7069,15 +7069,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
 Class: OEO_00010248
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generation process is an energy transformation that has thermal energy as energy output.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "heat generation",
+        rdfs:label "heat generation process"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1045
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1130
 
 Add alternative term:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generation process is an energy transformation that has thermal energy as energy output.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "heat generation",
-        rdfs:label "heat generation process"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562"
     
     EquivalentTo: 
         OEO_00020003
@@ -7090,35 +7090,35 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
 Class: OEO_00010249
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion thermal energy transformation is an energy transformation that converts chemical energy of a combustion fuel into thermal energy.",
+        rdfs:label "combustion thermal energy transformation"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1045
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1130
 
 Add relation to emission
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1045
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1210",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion thermal energy transformation is an energy transformation that converts chemical energy of a combustion fuel into thermal energy.",
-        rdfs:label "combustion thermal energy transformation"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1210"
     
     SubClassOf: 
         OEO_00020003,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140038,
+        <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147,
         OEO_00000532 some OEO_00000099,
         OEO_00010234 some OEO_00000007,
-        OEO_00010235 some OEO_00000207,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140038,
-        <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147
+        OEO_00010235 some OEO_00000207
     
     
 Class: OEO_00010253
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Traction is a process of pushing or pulling to drive an object.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "propulsion",
+        rdfs:label "traction"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1029
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135
 relabel
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1528
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1541",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Traction is a process of pushing or pulling to drive an object.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "propulsion",
-        rdfs:label "traction"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1541"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -7128,12 +7128,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1541",
 Class: OEO_00010254
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1029
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A traction motor is a motor that is used for propulsion.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Antriebsmotor"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Traktionsmotor"@de,
-        rdfs:label "traction motor"@en
+        rdfs:label "traction motor"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1029
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135"
     
     EquivalentTo: 
         OEO_00010032
@@ -7146,15 +7146,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1135",
 Class: OEO_00010256
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A maximum value is a quantity value that represents the upper limit of an artificial object or process to contain or transform another entity.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Maximalwert"@de,
+        rdfs:label "maximum value"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
 
 Made 'energy storage capacity' subclass of \"maximum value'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A maximum value is a quantity value that represents the upper limit of an artificial object or process to contain or transform another entity.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Maximalwert"@de,
-        rdfs:label "maximum value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486"
     
     SubClassOf: 
         OEO_00000350
@@ -7163,6 +7163,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
 Class: OEO_00010257
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power capacity is a power rating of a generator or power generating unit to generate power.",
+        rdfs:label "power capacity"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
 
@@ -7172,9 +7174,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1235
 
 Restructure 'power rating' and 'power capacity':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1492
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1770",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power capacity is a power rating of a generator or power generating unit to generate power.",
-        rdfs:label "power capacity"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1770"
     
     SubClassOf: 
         OEO_00230001,
@@ -7203,11 +7203,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1188",
 Class: OEO_00010259
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1214
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A measurement device is an artificial object that is used in some measurement process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Messgerät"@de,
-        rdfs:label "measurement device"@en
+        rdfs:label "measurement device"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1214
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215"
     
     SubClassOf: 
         OEO_00000061
@@ -7216,15 +7216,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1215",
 Class: OEO_00010263
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Personentransport"@de,
+        rdfs:label "passenger transport"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger transport is a transport process in which people are moved in a vehicle from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Personentransport"@de,
-        rdfs:label "passenger transport"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00140003,
@@ -7237,6 +7237,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010264
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Passagier"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Passagierin"@de,
+        rdfs:label "passenger"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
 
@@ -7246,11 +7250,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger is an agent who travels in a vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Passagier"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Passagierin"@de,
-        rdfs:label "passenger"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00000051,
@@ -7260,14 +7260,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00010265
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
+        rdfs:label "energy service demand for passenger-kilometre"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for passenger-kilometre is the energy service demand that is consumed to transport one person over a distance of one kilometre.",
-        rdfs:label "energy service demand for passenger-kilometre"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00240024,
@@ -7277,14 +7277,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010266
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
+        rdfs:label "energy service demand for ton-kilometre"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1055
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy service demand for ton-kilometre is the energy service demand that is consumed to transport one metric ton over a distance of one kilometre.",
-        rdfs:label "energy service demand for ton-kilometre"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00240024,
@@ -7294,11 +7294,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010267
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1211
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam reforming process is a chemical reaction that converts hydrocarbons and steam to syngas. As it converts chemical energy and thermal energy to a different type of chemical energy (and waste heat), it is also an energy transformation process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Dampfreformierung"@de,
-        rdfs:label "steam reforming"@en
+        rdfs:label "steam reforming"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1211
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251"
     
     SubClassOf: 
         OEO_00140033,
@@ -7313,15 +7313,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1251",
 Class: OEO_00010273
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A land vehicle is a vehicle that is moved by applying forces against the ground.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Landfahrzeug"@de,
+        rdfs:label "land vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293
 
 fixing bugs
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1898
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1899",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A land vehicle is a vehicle that is moved by applying forces against the ground.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Landfahrzeug"@de,
-        rdfs:label "land vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1899"
     
     SubClassOf: 
         OEO_00010023
@@ -7330,11 +7330,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1899",
 Class: OEO_00010274
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A road vehicle is a vehicle that uses roads.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Straßenfahrzeug"@de,
-        rdfs:label "road vehicle"@en
+        rdfs:label "road vehicle"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010273
@@ -7343,10 +7343,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010275
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A motorised road vehicle is a road vehicle that has a traction motor.",
-        rdfs:label "motorised road vehicle"@en
+        rdfs:label "motorised road vehicle"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010274,
@@ -7356,12 +7356,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010276
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A car is a motorised road vehicle that is used for passenger transport and has a maximum of eight seats.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Auto"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "automobile"@en,
-        rdfs:label "car"@en
+        rdfs:label "car"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010275,
@@ -7371,12 +7371,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010277
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bus is a motorised road vehicle that is used for passenger transport and has more than eight seats.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Bus"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "autobus"@en,
-        rdfs:label "bus"@en
+        rdfs:label "bus"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010275,
@@ -7386,14 +7386,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010278
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A truck is a motorised road vehicle that is used for freight transport.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LKW"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Lastkraftwagen"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Lastwagen"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "lorry"@en,
-        rdfs:label "truck"@en
+        rdfs:label "truck"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010275,
@@ -7403,11 +7403,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010279
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bicycle is a road vehicle that has two wheels and is propelled by a person.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Fahrrad"@de,
-        rdfs:label "bicycle"@en
+        rdfs:label "bicycle"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010274,
@@ -7417,11 +7417,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010280
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A train is a vehicle that uses railway tracks.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Zug"@de,
-        rdfs:label "train"@en
+        rdfs:label "train"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010273
@@ -7430,11 +7430,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010281
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A freight train is a train that is used for freight transport.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Güterzug"@de,
-        rdfs:label "freight train"@en
+        rdfs:label "freight train"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010280,
@@ -7444,11 +7444,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010282
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger train is a train that is used for passenger transport.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Personenzug"@de,
-        rdfs:label "passenger train"@en
+        rdfs:label "passenger train"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010280,
@@ -7458,16 +7458,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010283
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An e-bike is a bicycle that is propelled by a person and an electric traction motor.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "E-Bike"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Elektrofahrrad"@de,
+        rdfs:label "e-bike"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293
 
 Add 'traction battery' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An e-bike is a bicycle that is propelled by a person and an electric traction motor.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "E-Bike"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Elektrofahrrad"@de,
-        rdfs:label "e-bike"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"
     
     SubClassOf: 
         OEO_00010279,
@@ -7478,12 +7478,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
 Class: OEO_00010284
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A motorcycle is a motorised road vehicle that has two wheels.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Motorrad"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "motorbike"@en,
-        rdfs:label "motorcycle"@en
+        rdfs:label "motorcycle"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010275,
@@ -7493,11 +7493,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010285
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A watercraft is a vehicle that is driving through water.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserfahrzeug"@de,
-        rdfs:label "watercraft"@en
+        rdfs:label "watercraft"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010023
@@ -7506,11 +7506,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010286
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A ship is a watercraft of significant size that is driving on the water surface.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Schiff"@de,
-        rdfs:label "ship"@en
+        rdfs:label "ship"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010285
@@ -7519,11 +7519,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010287
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger ship is a ship that is used for passenger transport.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Passagierschiff"@de,
-        rdfs:label "passenger ship"@en
+        rdfs:label "passenger ship"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010286,
@@ -7533,11 +7533,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010288
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A cargo ship is a ship that is used for freight transport.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Frachtschiff"@de,
-        rdfs:label "cargo ship"@en
+        rdfs:label "cargo ship"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010286,
@@ -7547,11 +7547,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010289
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A container ship is a cargo ship used for the transport of containers.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Containerschiff"@de,
-        rdfs:label "container ship"@en
+        rdfs:label "container ship"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010288
@@ -7560,15 +7560,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010290
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A tank ship is a cargo ship used for the transport of liquid goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Tankschiff"@de,
+        rdfs:label "tank ship"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293
 
 Add tank axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A tank ship is a cargo ship used for the transport of liquid goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Tankschiff"@de,
-        rdfs:label "tank ship"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356"
     
     SubClassOf: 
         OEO_00010288,
@@ -7578,11 +7578,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
 Class: OEO_00010291
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A motorised vehicle is a vehicle that has a traction motor.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kraftfahrzeug"@de,
-        rdfs:label "motorised vehicle"@en
+        rdfs:label "motorised vehicle"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     EquivalentTo: 
         OEO_00010023
@@ -7595,11 +7595,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010292
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An aircraft is a vehicle that is flying in the air.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Luftfahrzeug"@de,
-        rdfs:label "aircraft"@en
+        rdfs:label "aircraft"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010023
@@ -7608,11 +7608,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010293
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An airplane is an aircraft that has fixed wings.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Flugzeug"@de,
-        rdfs:label "airplane"@en
+        rdfs:label "airplane"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010292
@@ -7621,12 +7621,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010294
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A helicopter is an aircraft that has rotating wings.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Helikopter"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Hubschrauber"@de,
-        rdfs:label "helicopter"@en
+        rdfs:label "helicopter"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1277
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293"
     
     SubClassOf: 
         OEO_00010292
@@ -7635,11 +7635,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1293",
 Class: OEO_00010295
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1270
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1295",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A conventional energy is an energy that has a conventional origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "konventionelle Energie"@de,
-        rdfs:label "conventional energy"@en
+        rdfs:label "conventional energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1270
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1295"
     
     EquivalentTo: 
         OEO_00000150
@@ -7655,31 +7655,31 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1295",
 Class: OEO_00010300
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A current collector is an energy converting component that transfers electrical energy between a stationary conductor and a grid supplied electric vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Stromabnehmer"@de,
-        rdfs:label "current collector"@en
+        rdfs:label "current collector"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"
     
     SubClassOf: 
         OEO_00000011,
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00010031,
         OEO_00010234 some OEO_00000139,
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00010031
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00010301
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine vehicle is a vehicle that uses a gas turbine for propulsion.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Gasturbinenfahrzeug"@de,
+        rdfs:label "gas turbine vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315
 
 Add fuel tank axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine vehicle is a vehicle that uses a gas turbine for propulsion.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Gasturbinenfahrzeug"@de,
-        rdfs:label "gas turbine vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356"
     
     EquivalentTo: 
         OEO_00010023
@@ -7695,10 +7695,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
 Class: OEO_00010302
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A jet fuel vehicle is a gas turbine vehicle that uses a jet fuel turbine.",
-        rdfs:label "jet fuel vehicle"@en
+        rdfs:label "jet fuel vehicle"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"
     
     EquivalentTo: 
         OEO_00010301
@@ -7713,12 +7713,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
 Class: OEO_00010303
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A jet fuel turbine is a turbine fueled with jet fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "aviation turbine",
         <http://purl.obolibrary.org/obo/IAO_0000118> "jet turbine",
-        rdfs:label "jet fuel turbine"@en
+        rdfs:label "jet fuel turbine"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"
     
     SubClassOf: 
         OEO_00000185,
@@ -7728,12 +7728,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315",
 Class: OEO_00010313
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/864
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sectoral energy consumption is the energy use of a sector.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "sectoral energy use"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "sektoraler Energieverbrauch"@de,
-        rdfs:label "sectoral energy consumption"@en
+        rdfs:label "sectoral energy consumption"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/864
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321"
     
     SubClassOf: 
         OEO_00010210,
@@ -7743,11 +7743,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321",
 Class: OEO_00010314
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/864
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sectoral emission is an emission caused by a certain sector.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "sektorale Emission"@de,
-        rdfs:label "sectoral emission"@en
+        rdfs:label "sectoral emission"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/864
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321"
     
     SubClassOf: 
         OEO_00000147,
@@ -7757,6 +7757,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1321",
 Class: OEO_00010315
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil refining process is a secondary energy production that converts crude oil by cracking and distillation into various mineral oil products.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Mineralölraffination"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "mineral oil refining"@en,
+        rdfs:label "mineral oil refining process"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
 
@@ -7770,24 +7774,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil refining process is a secondary energy production that converts crude oil by cracking and distillation into various mineral oil products.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Mineralölraffination"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "mineral oil refining"@en,
-        rdfs:label "mineral oil refining process"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00010127,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140033,
         OEO_00000532 some OEO_00000115,
         OEO_00000533 some OEO_00010316,
         OEO_00010234 some OEO_00000007,
-        OEO_00010235 some OEO_00000007,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140033
+        OEO_00010235 some OEO_00000007
     
     
 Class: OEO_00010316
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil product is a fossil combustion fuel produced in a mineral oil refining process.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Mineralölprodukt"@de,
+        rdfs:label "mineral oil product"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331
 
@@ -7801,10 +7804,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil product is a fossil combustion fuel produced in a mineral oil refining process.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Mineralölprodukt"@de,
-        rdfs:label "mineral oil product"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00000014
@@ -7818,11 +7818,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010317
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil is a fossil combustion fuel that is either crude oil or a mineral oil product.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Mineralöl"@de,
-        rdfs:label "mineral oil"@en
+        rdfs:label "mineral oil"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331"
     
     EquivalentTo: 
         OEO_00000014
@@ -7835,25 +7835,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
 Class: OEO_00010318
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral oil refinery is an energy transformation unit that applies a mineral oil refining process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Mineralölraffinerie"@de,
-        rdfs:label "mineral oil refinery"@en
+        rdfs:label "mineral oil refinery"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1318
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1331"
     
     SubClassOf: 
         OEO_00020102,
-        OEO_00000503 some OEO_00000115,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010315
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010315,
+        OEO_00000503 some OEO_00000115
     
     
 Class: OEO_00010321
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical energy storage function is an energy storage function with chemical energy as input and output.",
-        rdfs:label "chemical energy storage function"@en
+        rdfs:label "chemical energy storage function"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348"
     
     SubClassOf: 
         OEO_00000012
@@ -7862,10 +7862,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00010322
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy storage function is an energy storage function with electrical energy as input and output.",
-        rdfs:label "electrical energy storage function"@en
+        rdfs:label "electrical energy storage function"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348"
     
     SubClassOf: 
         OEO_00000012
@@ -7874,10 +7874,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00010323
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A kinetic energy storage function is an energy storage function with kinetic energy as input and output.",
-        rdfs:label "kinetic energy storage function"@en
+        rdfs:label "kinetic energy storage function"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348"
     
     SubClassOf: 
         OEO_00000012
@@ -7886,15 +7886,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00010324
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A potential energy storage function is an energy storage function with potential energy as input and output.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "This function was introduce for the sake of completeness, but there is no actual use case seen at the moment.",
+        rdfs:label "potential energy storage function"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348
 
 add editor note
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A potential energy storage function is an energy storage function with potential energy as input and output.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "This function was introduce for the sake of completeness, but there is no actual use case seen at the moment.",
-        rdfs:label "potential energy storage function"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     SubClassOf: 
         OEO_00000012
@@ -7903,10 +7903,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00010325
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An underground fuel storage object is an energy storage object that stores chemical energy in form of fuels underground.",
-        rdfs:label "underground fuel storage object"@en
+        rdfs:label "underground fuel storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1262
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348"
     
     SubClassOf: 
         OEO_00000159,
@@ -7916,52 +7916,52 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1348",
 Class: OEO_00010326
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1332
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1351",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Refinery gas is a gas mixture that is produced as a by-product of a mineral oil refining process. It mainly consists of hydrogen, methane, ethane and olefins and can be used as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Raffineriegas"@de,
-        rdfs:label "refinery gas"@en
+        rdfs:label "refinery gas"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1332
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1351"
     
     SubClassOf: 
         OEO_00010236,
-        OEO_00000530 some OEO_00030002,
-        OEO_00240025 some OEO_00010315,
         <http://purl.obolibrary.org/obo/BFO_0000051> some 
             (OEO_00000025
              and OEO_00000220),
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000530 some OEO_00030002,
+        OEO_00240025 some OEO_00010315,
         OEO_00000529 value OEO_00000182
     
     
 Class: OEO_00010327
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1332
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1351",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Petroleum coke is a portion of matter with a solid state of matter that is produced in a mineral oil refining process. It consists mainly of carbon and can be uses as a fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Petrolkoks"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "coke"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "pet coke"@en,
-        rdfs:label "petroleum coke"@en
+        rdfs:label "petroleum coke"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1332
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1351"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030002,
-        OEO_00240025 some OEO_00010315,
         <http://purl.obolibrary.org/obo/RO_0000087> some OEO_00000001,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        OEO_00000530 some OEO_00030002,
+        OEO_00240025 some OEO_00010315,
         OEO_00000529 value OEO_00000390
     
     
 Class: OEO_00010332
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1385",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainability criterion is a plan specification that intends to meet the needs of the present without compromising the ability of future generations to meet their own environmental, economic and social needs.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Nachhaltigkeitskriterium"@de,
-        rdfs:label "sustainability criterion"@en
+        rdfs:label "sustainability criterion"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1385"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000104>
@@ -7970,28 +7970,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1385",
 Class: OEO_00010333
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Material sustainability is a disposition is a material entity that conforms to some sustainability criteria.",
+        rdfs:label "material sustainability"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1385
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Material sustainability is a disposition is a material entity that conforms to some sustainability criteria.",
-        rdfs:label "material sustainability"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
-        OEO_00010231 some OEO_00010332,
-        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
+        <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>,
+        OEO_00010231 some OEO_00010332
     
     
 Class: OEO_00010334
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1385",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Process sustainability is a process attribute that conforms to some sustainability criteria.",
-        rdfs:label "process sustainability"@en
+        rdfs:label "process sustainability"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1385"
     
     SubClassOf: 
         OEO_00030019,
@@ -8001,11 +8001,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1385",
 Class: OEO_00010335
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1385",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable process is a process that has a process sustainability attribute.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "nachhaltiger Prozess"@de,
-        rdfs:label "sustainable process"@en
+        rdfs:label "sustainable process"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1385"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -8018,10 +8018,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1385",
 Class: OEO_00010336
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable biofuel is a biofuel that does conform to sustainability criteria.",
-        rdfs:label "sustainable biofuel"@en
+        rdfs:label "sustainable biofuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409"
     
     EquivalentTo: 
         OEO_00000072
@@ -8038,10 +8038,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
 Class: OEO_00010337
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-sustainable biofuel is a biofuel that does not conform to sustainability criteria.",
-        rdfs:label "non-sustainable biofuel"@en
+        rdfs:label "non-sustainable biofuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409"
     
     EquivalentTo: 
         OEO_00000072
@@ -8058,14 +8058,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409",
 Class: OEO_00010361
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power unit is a power generating unit that has the function to transform renewable energy.",
+        rdfs:label "renewable power unit"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power unit is a power generating unit that has the function to transform renewable energy.",
-        rdfs:label "renewable power unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00000334
@@ -8079,15 +8079,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010362
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power plant is a power plant that has renewable power units as parts.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Erneuerbare-Energien-Kraftwerk"@de,
+        rdfs:label "renewable power plant"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1423
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable power plant is a power plant that has renewable power units as parts.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Erneuerbare-Energien-Kraftwerk"@de,
-        rdfs:label "renewable power plant"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00000031
@@ -8100,11 +8100,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00010379
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electrolytic hydrogen is hydrogen that is a physical output of a water electrolysis process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Elektrolysewasserstoff"@de,
-        rdfs:label "electrolytic hydrogen"@en
+        rdfs:label "electrolytic hydrogen"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442"
     
     EquivalentTo: 
         OEO_00000220
@@ -8118,12 +8118,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
 Class: OEO_00010380
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable electrolytic hydrogen is electrolytic hydrogen that is produced with renewable electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbarer Elektrolysewasserstoff"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "green hydrogen"@en,
-        rdfs:label "renewable electrolytic hydrogen"@en
+        rdfs:label "renewable electrolytic hydrogen"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442"
     
     EquivalentTo: 
         OEO_00010379
@@ -8140,10 +8140,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
 Class: OEO_00010381
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Steam reforming hydrogen is hydrogen that is a physical output of a steam reforming process.",
-        rdfs:label "steam reforming hydrogen"@en
+        rdfs:label "steam reforming hydrogen"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442"
     
     EquivalentTo: 
         OEO_00000220
@@ -8157,11 +8157,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
 Class: OEO_00010382
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil steam reforming hydrogen is hydrogen that is produced from a fossil combustion fuel in a steam reforming process which is not followed by a carbon capture and storage process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "grey hydrogen",
-        rdfs:label "fossil steam reforming hydrogen"@en
+        rdfs:label "fossil steam reforming hydrogen"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442"
     
     EquivalentTo: 
         OEO_00000220
@@ -8172,43 +8172,43 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
     
     SubClassOf: 
         OEO_00000220,
+        <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00020148,
         OEO_00000530 some OEO_00030002,
-        OEO_00000530 some OEO_00030005,
-        <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00020148
+        OEO_00000530 some OEO_00030005
     
     
 Class: OEO_00010383
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Abated steam reforming hydrogen is hydrogen that is output of a steam reforming process which is followed by a carbon capture and storage process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CCS steam reforming hydrogen",
         <http://purl.obolibrary.org/obo/IAO_0000118> "blue hydrogen",
-        rdfs:label "abated steam reforming hydrogen"@en
+        rdfs:label "abated steam reforming hydrogen"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442"
     
     EquivalentTo: 
         OEO_00000220
          and (OEO_00240025 some 
             (OEO_00010267
-             and (OEO_00000532 some OEO_00000014)
-             and (<http://purl.obolibrary.org/obo/RO_0002418> some OEO_00010141)))
+             and (<http://purl.obolibrary.org/obo/RO_0002418> some OEO_00010141)
+             and (OEO_00000532 some OEO_00000014)))
     
     SubClassOf: 
         OEO_00000220,
+        <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00020148,
         OEO_00000530 some OEO_00030002,
-        OEO_00000530 some OEO_00030005,
-        <http://purl.obolibrary.org/obo/RO_0000053> some OEO_00020148
+        OEO_00000530 some OEO_00030005
     
     
 Class: OEO_00010384
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable electrical energy is electrical energy with a renewable origin.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbare elektrische Energie"@de,
-        rdfs:label "renewable electrical energy"@en
+        rdfs:label "renewable electrical energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442"
     
     EquivalentTo: 
         OEO_00000139
@@ -8221,6 +8221,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1442",
 Class: OEO_00010385
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation function is the function of an artificial object that has been engineered to transform input energy into usable output energy of a different type.",
+        rdfs:label "energy transformation function"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
 
@@ -8237,9 +8239,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation function is the function of an artificial object that has been engineered to transform input energy into usable output energy of a different type.",
-        rdfs:label "energy transformation function"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
@@ -8250,6 +8250,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00010386
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation function is an energy transformation function to transform other types of energy to electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electrical energy generation function",
+        rdfs:label "electricity generation function"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
 
@@ -8262,10 +8265,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 Add 'realized in' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1539
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation function is an energy transformation function to transform other types of energy to electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electrical energy generation function",
-        rdfs:label "electricity generation function"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785"
     
     SubClassOf: 
         OEO_00010385,
@@ -8275,15 +8275,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785",
 Class: OEO_00010387
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generation function is an energy transformation function to transform other types of energy to thermal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "thermal energy transformation function",
+        rdfs:label "heat generation function"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
 
 Add 'realized in' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1539
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generation function is an energy transformation function to transform other types of energy to thermal energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "thermal energy transformation function",
-        rdfs:label "heat generation function"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785"
     
     SubClassOf: 
         OEO_00010385,
@@ -8293,6 +8293,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785",
 Class: OEO_00010388
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy function is the energy transformation function to transform renewable energy.",
+        rdfs:label "renewable energy transformation function"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1438
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1445
 
@@ -8305,9 +8307,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 Add 'realized in' axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1539
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy function is the energy transformation function to transform renewable energy.",
-        rdfs:label "renewable energy transformation function"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785"
     
     SubClassOf: 
         OEO_00010385,
@@ -8319,10 +8319,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785",
 Class: OEO_00010392
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Direct solar radiation is radiation that is the non-scattered part of solar radiation from the sun within the extent of the solar disk only.",
-        rdfs:label "direct solar radiation"@en
+        rdfs:label "direct solar radiation"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
     
     SubClassOf: 
         OEO_00020038
@@ -8334,11 +8334,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
 Class: OEO_00010393
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Diffuse solar radiation is radiation that is the part of solar radiation that has been scattered by gas molecules in the atmosphere and by particles such as cloud droplets and aerosols.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "diffuse Solarstrahlung"@de,
-        rdfs:label "diffuse solar radiation"@en
+        rdfs:label "diffuse solar radiation"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
     
     SubClassOf: 
         OEO_00020038
@@ -8350,10 +8350,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
 Class: OEO_00010394
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-scattered radiant flux density is an areal solar power density that measures the direct solar radiation within the extent of the solar disk only (half-angle 0.266 deg).",
-        rdfs:label "non-scattered radiant flux density"@en
+        rdfs:label "non-scattered radiant flux density"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
     
     EquivalentTo: 
         OEO_00020056 some OEO_00010392
@@ -8365,11 +8365,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
 Class: OEO_00010395
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar tracking is a process in which a radiation receiving surface is following the path of the sun on the sky.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Sonnennachführung"@de,
-        rdfs:label "solar tracking"@en
+        rdfs:label "solar tracking"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -8378,11 +8378,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
 Class: OEO_00010396
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Single axis tracking is solar tracking in which a radiation receiving surface is following the path of the sun by roting along a fixed axis. Typical axis orientations are North-South or East-West.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Einachs-Nachführung"@de,
-        rdfs:label "single axis tracking"@en
+        rdfs:label "single axis tracking"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
     
     SubClassOf: 
         OEO_00010395
@@ -8391,11 +8391,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
 Class: OEO_00010397
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Two axis tracking is solar tracking in which a radiation receiving surface is following the sun by rotating around two axes. The surface is always oriented normal.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Zweiachs-Nachführung"@de,
-        rdfs:label "two axis tracking"@en
+        rdfs:label "two axis tracking"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
     
     SubClassOf: 
         OEO_00010395
@@ -8404,10 +8404,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
 Class: OEO_00010398
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar tracked receiving surface is a solar radiation receiving surface that participates in solar tracking.",
-        rdfs:label "solar tracked receiving surface"@en
+        rdfs:label "solar tracked receiving surface"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
     
     EquivalentTo: 
         OEO_00020199
@@ -8420,10 +8420,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
 Class: OEO_00010399
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A single axis tracked receiving surface is a solar radiation receiving surface that participates in single axis tracking.",
-        rdfs:label "single axis tracked receiving surface"@en
+        rdfs:label "single axis tracked receiving surface"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
     
     EquivalentTo: 
         OEO_00020199
@@ -8436,10 +8436,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
 Class: OEO_00010400
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A two axis tracked receiving surface is a solar radiation receiving surface that participates in two axis tracking.",
-        rdfs:label "two axis tracked receiving surface"@en
+        rdfs:label "two axis tracked receiving surface"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
     
     EquivalentTo: 
         OEO_00020199
@@ -8452,10 +8452,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
 Class: OEO_00010401
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1439
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1456",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-only generating unit is a power generating unit that has only the function to produce electrical energy.",
-        rdfs:label "power-only generating unit"@en
+        rdfs:label "power-only generating unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1439
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1456"
     
     EquivalentTo: 
         OEO_00000334
@@ -8470,10 +8470,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1456",
 Class: OEO_00010408
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Brent crude is a crude oil that is extracted in the North Sea and traded at ICE London.",
-        rdfs:label "Brent crude"@en
+        rdfs:label "Brent crude"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478"
     
     SubClassOf: 
         OEO_00000115
@@ -8482,11 +8482,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
 Class: OEO_00010409
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Western Texas Intermediate (WTI) is a crude oil that is extracted on US territory and traded at NYMEX New York.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "WTI",
-        rdfs:label "Western Texas Intermediate"@en
+        rdfs:label "Western Texas Intermediate"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1458
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478"
     
     SubClassOf: 
         OEO_00000115
@@ -8495,6 +8495,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478",
 Class: OEO_00010410
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transfer function is a function of an artificial object that has been engineered to transfer energy over a spatial distance.",
+        rdfs:label "energy transfer function"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1454
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1515
 
@@ -8504,9 +8506,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transfer function is a function of an artificial object that has been engineered to transfer energy over a spatial distance.",
-        rdfs:label "energy transfer function"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
@@ -8517,10 +8517,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00010413
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1361
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1557",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A subsurface collector is a heat exchanger that transfers ambient thermal energy to a working fluid. It consists of plastic pipes laid horizontally under the ground.",
-        rdfs:label "subsurface collector"@en
+        rdfs:label "subsurface collector"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1361
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1557"
     
     SubClassOf: 
         OEO_00140102
@@ -8529,10 +8529,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1557",
 Class: OEO_00010414
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1361
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1557",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A downhole heat exchanger is a heat exchanger that transfers ambient thermal energy or geothermal energy to a working fluid. It consists of plastic pipes installed vertically or inclined in a borehole.",
-        rdfs:label "downhole heat exchanger"@en
+        rdfs:label "downhole heat exchanger"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1361
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1557"
     
     SubClassOf: 
         OEO_00140102
@@ -8541,10 +8541,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1557",
 Class: OEO_00010415
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1491
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear is a conventional origin that indicates that the energy comes originally from nuclear binding energy.",
-        rdfs:label "nuclear"@en
+        rdfs:label "nuclear"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1491
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559"
     
     SubClassOf: 
         OEO_00020147
@@ -8553,11 +8553,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
 Class: OEO_00010416
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear electrolytic hydrogen is electrolytic hydrogen that is produced with nuclear electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "pink hydrogen",
-        rdfs:label "nuclear electric hydrogen"@en
+        rdfs:label "nuclear electric hydrogen"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559"
     
     EquivalentTo: 
         OEO_00010379
@@ -8572,10 +8572,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
 Class: OEO_00010417
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear electrical energy is electrical energy with a nuclear origin.",
-        rdfs:label "nuclear electrical energy"@en
+        rdfs:label "nuclear electrical energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559"
     
     EquivalentTo: 
         OEO_00000139
@@ -8588,11 +8588,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
 Class: OEO_00010418
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar electrolytic hydrogen is electrolytic hydrogen that is produced with solar electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "yellow hydrogen",
-        rdfs:label "solar electrolytic hydrogen"@en
+        rdfs:label "solar electrolytic hydrogen"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559"
     
     EquivalentTo: 
         OEO_00010379
@@ -8607,10 +8607,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
 Class: OEO_00010419
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar electrical energy is electrical energy that is energy output of a solar energy transformation.",
-        rdfs:label "solar electrical energy"@en
+        rdfs:label "solar electrical energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559"
     
     EquivalentTo: 
         OEO_00000139
@@ -8624,10 +8624,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559",
 Class: OEO_00010420
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel production is a production process which has fuel as physical output.",
-        rdfs:label "fuel production"@en
+        rdfs:label "fuel production"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575"
     
     EquivalentTo: 
         OEO_00240003
@@ -8640,10 +8640,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575",
 Class: OEO_00010423
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power generation technology is an energy technology that describes how to combine power generating units and energy carriers in a power generation process to generate electrical energy.",
-        rdfs:label "power generation technology"@en
+        rdfs:label "power generation technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00020267,
@@ -8655,10 +8655,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010424
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A wind power technology is a power generation technology that describes how to combine wind energy converting units and a wind energy transformation.",
-        rdfs:label "wind power technology"@en
+        rdfs:label "wind power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010423,
@@ -8669,10 +8669,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010425
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An onshore wind power technology is a wind power generation technology that describes how to use wind energy converting units in onshore wind farms.",
-        rdfs:label "onshore wind power technology"@en
+        rdfs:label "onshore wind power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010424,
@@ -8685,10 +8685,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010426
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An offshore wind power technology is a wind power generation technology that describes how to use wind energy converting units in offshore wind farms.",
-        rdfs:label "offshore wind power technology"@en
+        rdfs:label "offshore wind power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010424,
@@ -8701,10 +8701,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010427
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar power technology is a power generation technology that describes how to combine solar power units in an electricity generation process with solar energy as input.",
-        rdfs:label "solar power technology"@en
+        rdfs:label "solar power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010423,
@@ -8717,10 +8717,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010428
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A photovoltaic technology is a power generation technology that describes how to combine photovoltaic panels in an electricity generation process with solar energy as input.",
-        rdfs:label "photovoltaic technology"@en
+        rdfs:label "photovoltaic technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010427,
@@ -8733,10 +8733,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010429
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal power technology is a power generation technology that describes how to combine solar thermal power units in an electricity generation process with solar energy as input.",
-        rdfs:label "solar thermal power technology"@en
+        rdfs:label "solar thermal power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010427,
@@ -8749,10 +8749,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010430
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal power technology is a power generation technology that describes how to combine geothermal power units in an electricity generation process with geothermal energy as input.",
-        rdfs:label "geothermal power technology"@en
+        rdfs:label "geothermal power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010423,
@@ -8765,10 +8765,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010431
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydro power technology is a power generation technology that describes how to combine hydro power units and a hydroelectric energy transformation.",
-        rdfs:label "hydro power technology"@en
+        rdfs:label "hydro power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010423,
@@ -8780,10 +8780,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010432
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir hydro storage power technology is a power generation technology that describes how to combine hydro power units in run of river power plant and a hydroelectric energy transformation.",
-        rdfs:label "run of river power technology"@en
+        rdfs:label "run of river power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010431,
@@ -8796,10 +8796,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010433
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A reservoir hydro storage power technology is a power generation technology that describes how to combine hydro power units in reservoir hydro storage power plants and a hydroelectric energy transformation.",
-        rdfs:label "reservoir hydro storage power technology"@en
+        rdfs:label "reservoir hydro storage power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010431,
@@ -8812,10 +8812,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010434
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine hydro power technology is a hydro power technology that describes how to combine hydro power units, a hydroelectric energy transformation and oceans.",
-        rdfs:label "marine hydro power technology"@en
+        rdfs:label "marine hydro power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010431,
@@ -8829,10 +8829,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010435
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine current energy technology is a marine hydro power technology that describes how to combine marine current energy converting units in marine current energy transformations.",
-        rdfs:label "marine current energy technology"@en
+        rdfs:label "marine current energy technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010434,
@@ -8843,10 +8843,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010436
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine tidal energy technology is a marine hydro power technology that describes how to combine marine tidal energy converting units in marine tidal energy transformations.",
-        rdfs:label "marine tidal energy technology"@en
+        rdfs:label "marine tidal energy technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010434,
@@ -8857,10 +8857,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010437
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A marine wave energy technology is a marine hydro power technology that describes how to combine marine wave energy converting units in marine wave energy transformations.",
-        rdfs:label "marine wave energy technology"@en
+        rdfs:label "marine wave energy technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010434,
@@ -8871,10 +8871,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010438
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A pumped hydro storage power technology is a power generation technology that describes how to combine hydro power units in pumped hydro storage power plants and a hydroelectric energy transformation.",
-        rdfs:label "pumped hydro storage power technology"@en
+        rdfs:label "pumped hydro storage power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010431,
@@ -8887,10 +8887,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010439
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A nuclear power generation technology is a power generation technology that describes how to combine nuclear power units and nuclear fuel in an electricity generation process.",
-        rdfs:label "nuclear power technology"@en
+        rdfs:label "nuclear power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010423,
@@ -8903,10 +8903,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010440
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel-powered generation technology is a power technology that describes how to combine fuel-powered units in a fuel-powered electricity generation process.",
-        rdfs:label "fuel power technology"@en
+        rdfs:label "fuel power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010423,
@@ -8917,10 +8917,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010441
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coal power technology is a fuel-powered technology that describes how to combine coal power units and coal in a fuel-powered electricity generation process.",
-        rdfs:label "coal power technology"@en
+        rdfs:label "coal power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010440,
@@ -8933,10 +8933,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010442
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hard coal power technology is a coal power technology that describes how to combine hard coal power units and hard coal in a fuel-powered electricity generation process.",
-        rdfs:label "hard coal power technology"@en
+        rdfs:label "hard coal power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010441,
@@ -8949,10 +8949,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010443
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A lignite power technology is a coal power technology that describes how to combine hard coal power units and lignite in a fuel-powered electricity generation process.",
-        rdfs:label "lignite power technology"@en
+        rdfs:label "lignite power technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010441,
@@ -8965,10 +8965,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601",
 Class: OEO_00010445
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1504
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A blended liquid fuel is a liquid combustion fuel that contains a liquid fossil fuel and a liquid renewable fuel or a liquid biofuel."@en,
-        rdfs:label "blended liquid fuel"@en
+        rdfs:label "blended liquid fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1504
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723"
     
     EquivalentTo: 
         OEO_00010145
@@ -8983,10 +8983,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
 Class: OEO_00010446
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1504
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Bioethanol is ethanol with a biogenic origin."@en,
-        rdfs:label "bioethanol"@en
+        rdfs:label "bioethanol"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1504
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723"
     
     EquivalentTo: 
         OEO_00020001
@@ -8999,14 +8999,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723",
 Class: OEO_00010447
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "E10 is a gasoline fuel that consists of (fossil) gasoline and up to 10 % ethanol and that is liquid."@en,
+        rdfs:label "E10"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1504
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723
 
 Make liquid fuel:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1764
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1774",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "E10 is a gasoline fuel that consists of (fossil) gasoline and up to 10 % ethanol and that is liquid."@en,
-        rdfs:label "E10"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1774"
     
     SubClassOf: 
         OEO_00010241,
@@ -9018,14 +9018,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1774",
 Class: OEO_00010448
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "B7 is a diesel fuel that consists of fossil diesel fuel and up to 7 % biodiesel and that is liquid."@en,
+        rdfs:label "B7"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1504
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1723
 
 Make liquid fuel:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1764
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1774",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "B7 is a diesel fuel that consists of fossil diesel fuel and up to 7 % biodiesel and that is liquid."@en,
-        rdfs:label "B7"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1774"
     
     SubClassOf: 
         OEO_00010242,
@@ -9037,10 +9037,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1774",
 Class: OEO_00010449
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A mobility technology is a technology that describes how vehicles participate in transport"@en,
-        rdfs:label "mobility technology"@en
+        rdfs:label "mobility technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727"
     
     SubClassOf: 
         OEO_00000407,
@@ -9052,10 +9052,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
 Class: OEO_00010450
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric mobility is a technology that describes how electric vehicles participate in transport."@en,
-        rdfs:label "electric mobility technology"@en
+        rdfs:label "electric mobility technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727"
     
     SubClassOf: 
         OEO_00010449,
@@ -9067,10 +9067,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1727",
 Class: OEO_00010451
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1413
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1763",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel blending quota is a quality of a blended fuel that indicates the share of liquid renewable fuel or liquid biofuel mixed into fossil fuel."@en,
-        rdfs:label "fuel blending quota"@en
+        rdfs:label "fuel blending quota"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1413
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1763"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>
@@ -9092,14 +9092,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1763",
 Class: OEO_00010453
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Temperature is a quality representing the driving force for the flow of heat energy and is a measure of the heat content of a material entity."@en,
+        rdfs:label "temperature"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1767
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Temperature is a quality representing the driving force for the flow of heat energy and is a measure of the heat content of a material entity."@en,
-        rdfs:label "temperature"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
@@ -9109,14 +9109,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00010454
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A pressure is a quality representing the force per unit area that its bearer exerts on itself or on a surface that bounds its bearer.",
+        rdfs:label "pressure"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1767
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A pressure is a quality representing the force per unit area that its bearer exerts on itself or on a surface that bounds its bearer.",
-        rdfs:label "pressure"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
@@ -9126,11 +9126,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00010455
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1760
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1768",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon capture and storage technology is a technology that describes how to combine artificial objects and a carbon capture and storage process in a specific way to permanently store CO2."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "CCS technology"@en,
-        rdfs:label "carbon capture and storage technology"@en
+        rdfs:label "carbon capture and storage technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1760
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1768"
     
     SubClassOf: 
         OEO_00000407,
@@ -9142,11 +9142,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1768",
 Class: OEO_00010471
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1773
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1803",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A non-energy use technology is a technology that describes among other things how to combine the consumption of energy carriers for non-energy use with other processes and artificial objects or other material entities in a specific way."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "non-energy consumption technology"@en,
-        rdfs:label "non-energy use technology"@en
+        rdfs:label "non-energy use technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1773
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1803"
     
     EquivalentTo: 
         OEO_00000407
@@ -9159,10 +9159,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1803",
 Class: OEO_00010480
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressor is a pump that converts energy into kinetic or potential energy of a gaseous fluid."@en,
-        rdfs:label "compressor"@en
+        rdfs:label "compressor"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818"
     
     SubClassOf: 
         OEO_00010090,
@@ -9174,10 +9174,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
 Class: OEO_00010481
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressor station is an energy transformation unit that has a compressor to enable gas transport via a gas grid."@en,
-        rdfs:label "compressor station"@en
+        rdfs:label "compressor station"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818"
     
     SubClassOf: 
         OEO_00020102,
@@ -9189,41 +9189,41 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
 Class: OEO_00010482
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine compressor station is a compressor station that has a gas turbine for driving the compressor."@en,
-        rdfs:label "gas turbine compressor station"@en
+        rdfs:label "gas turbine compressor station"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818"
     
     SubClassOf: 
         OEO_00010481,
-        OEO_00000503 some OEO_00010146,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000185
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000185,
+        OEO_00000503 some OEO_00010146
     
     
 Class: OEO_00010483
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electric compressor station is a compressor station that has en elecrtric motor for driving the compressor."@en,
-        rdfs:label "electric compressor station"@en
+        rdfs:label "electric compressor station"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1813
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1818"
     
     SubClassOf: 
         OEO_00010481,
-        OEO_00000503 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010027
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00010027,
+        OEO_00000503 some OEO_00000139
     
     
 Class: OEO_00010484
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1825
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1827",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Methanol is a hydrocarbon with the chemical formula CH3OH. It has a liquid normal state of matter. As it can be oxidised it can be used as a fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "CH3OH",
         <http://purl.obolibrary.org/obo/IAO_0000118> "CH4O",
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_17790",
-        rdfs:label "methanol"@en
+        rdfs:label "methanol"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1825
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1827"
     
     SubClassOf: 
         OEO_00140159,
@@ -9235,11 +9235,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1827",
 Class: OEO_00010485
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A manufacturing technology is a technology that describes how to combine manufactuing plants and manufacturing processes to produce manufactured materials."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "industrial technology"@en,
-        rdfs:label "manufacturing technology"@en
+        rdfs:label "manufacturing technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1726
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840"
     
     SubClassOf: 
         OEO_00000407,
@@ -9253,11 +9253,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840",
 Class: OEO_00010486
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A manufacturing plant is an artificial object that applies one or more manufacturing processes to produce one more kinds of manufactured materials."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "industrial plant"@en,
-        rdfs:label "manufacturing plant"@en
+        rdfs:label "manufacturing plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1726
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840"
     
     SubClassOf: 
         OEO_00000061,
@@ -9267,12 +9267,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840",
 Class: OEO_00010491
 
     Annotations: 
-        OEO_00020426 "Split 'industrial material' into 'manufactured material' and 'manufactured commodity':
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured commodity is a portion of matter that is the physical output of a manufacturing process and that has a commodity role."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "industrial commodity"@en,
-        rdfs:label "manufactured commodity"@en
+        rdfs:label "manufactured commodity"@en,
+        OEO_00020426 "Split 'industrial material' into 'manufactured material' and 'manufactured commodity':
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1726
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840"
     
     SubClassOf: 
         OEO_00000331
@@ -9281,12 +9281,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840",
 Class: OEO_00020001
 
     Annotations: 
-        OEO_00020426 "class:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
-axioms:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/703
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/704"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ethanol is a portion of matter with the chemical formula C2H6O. It has a liquid normal state of matter and can be used as a combustion fuel."@en,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
@@ -9297,7 +9291,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
         <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_16236",
-        rdfs:label "ethanol"@en
+        rdfs:label "ethanol"@en,
+        OEO_00020426 "class:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/439
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/445
+axioms:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/703
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/704"@en
     
     SubClassOf: 
         OEO_00000331,
@@ -9310,6 +9310,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
 Class: OEO_00020003
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Energieumwandlung"@de,
+        rdfs:label "energy transformation"@en,
         OEO_00020426 "class added:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/371
@@ -9352,10 +9355,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1625
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transformation is a transformation in which one or more certain types of energy as input result in certain types of energy as output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Energieumwandlung"@de,
-        rdfs:label "energy transformation"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en
     
     EquivalentTo: 
         OEO_00000419
@@ -9364,28 +9364,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
     
     SubClassOf: 
         OEO_00000419,
-        OEO_00000500 some OEO_00000333,
-        OEO_00000500 some OEO_00140049,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000011,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00020102,
+        OEO_00000500 some OEO_00000333,
+        OEO_00000500 some OEO_00140049
     
     
 Class: OEO_00020004
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Gasnetz"@de,
+        rdfs:label "gas grid"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Gasnetz"@de,
-        rdfs:label "gas grid"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
     SubClassOf: 
         OEO_00000200,
@@ -9395,15 +9395,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00020005
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Wärmenetz"@de,
+        rdfs:label "heating grid"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Wärmenetz"@de,
-        rdfs:label "heating grid"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
     SubClassOf: 
         OEO_00000200,
@@ -9413,6 +9413,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00020006
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Netzkomponente"@de,
+        rdfs:label "grid component"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385
 subclass of energy transformation unit
@@ -9420,10 +9423,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A grid component is an energy transformation unit that is a discrete part of a supply grid serving a specific purpose."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Netzkomponente"@de,
-        rdfs:label "grid component"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00020102,
@@ -9433,12 +9433,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020007
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid component is a grid component that is part of a gas grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gasnetzkomponente"@de,
-        rdfs:label "gas grid component"@en
+        rdfs:label "gas grid component"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en
     
     EquivalentTo: 
         OEO_00020006
@@ -9451,12 +9451,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00020008
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid component is a grid component that is part of a heating grid."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wärmenetzkomponente"@de,
-        rdfs:label "heating grid component"@en
+        rdfs:label "heating grid component"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en
     
     EquivalentTo: 
         OEO_00020006
@@ -9469,11 +9469,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
 Class: OEO_00020009
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A switchyard is an electricity grid component that connects different levels of voltage"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Schaltanlage"@de,
-        rdfs:label "switchyard"@en
+        rdfs:label "switchyard"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/231
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/385"@en
     
     SubClassOf: 
         OEO_00020006,
@@ -9487,11 +9487,6 @@ Class: OEO_00020011
 Class: OEO_00020037
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1031
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1447",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiation is an energy transfer by emitting or transmitting energy in the form of waves or particles through a spatial region or a material entity.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Strahlung"@de,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Adaptation of https://en.wikipedia.org/w/index.php?title=Radiation&oldid=986678480",
@@ -9503,7 +9498,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001023>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001023>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1031
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1447"
     
     SubClassOf: 
         OEO_00020103,
@@ -9513,12 +9513,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00020038
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600
-
-Add alternative label and editor note:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar radiation is radiation that is emitted by the sun.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "Solar radiation is the mereological sum of direct solar radiation and diffuse solar radiation",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Solarstrahlung"@de,
@@ -9531,7 +9525,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001862>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001862>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/362
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/600
+
+Add alternative label and editor note:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
     
     SubClassOf: 
         OEO_00020037
@@ -9540,6 +9540,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00020039
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has an energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Energieträger"@de,
+        rdfs:label "energy carrier"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/407
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/627
 move to oeo-shared
@@ -9549,10 +9552,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1169
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1173
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy carrier is a material entity that has an energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Energieträger"@de,
-        rdfs:label "energy carrier"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000040>
@@ -9565,8 +9565,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020040
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Radiative energy is energy that has been transmitted by a radiation process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Strahlungsenergie"@de,
         rdfs:label "radiative energy"@en,
@@ -9577,7 +9575,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000030>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000030>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/660
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/665"
     
     SubClassOf: 
         OEO_00000150
@@ -9586,28 +9586,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00020043
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Wind energy transformation is an energy transformation that converts wind energy to electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Windenergieumwandlung"@de,
-        rdfs:label "wind energy transformation"@en
+        rdfs:label "wind energy transformation"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702"
     
     SubClassOf: 
         OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044,
         OEO_00010234 some OEO_00000446,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00020045
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Lageenergie"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "potentielle Energie"@de,
         rdfs:comment "Potential energy is the energy that a material entity contains due to its position relative to other material entities or to stresses within itself.",
@@ -9619,7 +9617,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000016>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000016>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/628
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/670"
     
     SubClassOf: 
         OEO_00000150
@@ -9628,6 +9628,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00020046
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy transformation is an energy transformation that converts solar energy.",
+        rdfs:label "solar energy transformation"@en,
         OEO_00020426 "class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
@@ -9640,9 +9642,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar energy transformation is an energy transformation that converts solar energy.",
-        rdfs:label "solar energy transformation"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"
     
     SubClassOf: 
         OEO_00020003,
@@ -9652,55 +9652,55 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00020047
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy transformation is a solar energy transformation that converts solar energy into thermal energy.",
+        rdfs:label "solar thermal energy transformation"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Solar thermal energy transformation is a solar energy transformation that converts solar energy into thermal energy.",
-        rdfs:label "solar thermal energy transformation"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"
     
     SubClassOf: 
         OEO_00020046,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000387,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        OEO_00010235 some OEO_00000388,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000387
+        OEO_00010235 some OEO_00000388
     
     
 Class: OEO_00020048
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Photovoltaic energy transformation is a solar energy transformation that converts solar energy into electrical energy.",
+        rdfs:label "photovoltaic energy transformation"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/672
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Photovoltaic energy transformation is a solar energy transformation that converts solar energy into electrical energy.",
-        rdfs:label "photovoltaic energy transformation"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"
     
     SubClassOf: 
         OEO_00020046,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000032,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000032
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00020050
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier is an energy carrier that has a renewable energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbarer Energieträger"@de,
+        rdfs:label "renewable energy carrier"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
 change def and equivalence
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier is an energy carrier that has a renewable energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbarer Energieträger"@de,
-        rdfs:label "renewable energy carrier"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000040>
@@ -9713,11 +9713,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020053
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear fission is a process of nuclear reaction or a radioactive decay in which the nucleus of an atom splits into two or more smaller, lighter nuclei.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kernspaltung"@de,
-        rdfs:label "nuclear fission"@en
+        rdfs:label "nuclear fission"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -9727,16 +9727,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698",
 Class: OEO_00020054
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy transformation is an energy transformation that converts nuclear binding energy to thermal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "kernphysikalische Energieumwandlung"@de,
+        rdfs:label "nuclear energy transformation"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/692
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/698
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear energy transformation is an energy transformation that converts nuclear binding energy to thermal energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "kernphysikalische Energieumwandlung"@de,
-        rdfs:label "nuclear energy transformation"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"
     
     SubClassOf: 
         OEO_00020003,
@@ -9750,30 +9750,30 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00020058
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rock is a portion of matter that is a naturally occurring solid aggregate of minerals or mineraloid matter that is part of the earth's crust.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Fels"@de,
-        rdfs:label "rock"@en
+        rdfs:label "rock"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739"
     
     SubClassOf: 
         OEO_00000331,
-        OEO_00000530 some OEO_00030003,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
+        OEO_00000530 some OEO_00030003,
         OEO_00000529 value OEO_00000390
     
     
 Class: OEO_00020059
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal heat transfer is a heat transfer from the earth crust to a transportable material entity. E.g. a liquid or gas.",
+        rdfs:label "geothermal heat transfer"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/727
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/739
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Geothermal heat transfer is a heat transfer from the earth crust to a transportable material entity. E.g. a liquid or gas.",
-        rdfs:label "geothermal heat transfer"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"
     
     SubClassOf: 
         OEO_00140101,
@@ -9783,11 +9783,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041",
 Class: OEO_00020073
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Grid-bound heating is a heat transfer over a distance via a heating grid, using steam or (hot) water.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "distance heating",
-        rdfs:label "grid-bound heating"@en
+        rdfs:label "grid-bound heating"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770"
     
     SubClassOf: 
         OEO_00140101,
@@ -9799,10 +9799,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00020074
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial grid-bound heating is a grid-bound heating transfer to industrial installations."@en,
-        rdfs:label "industrial grid-bound heating"@en
+        rdfs:label "industrial grid-bound heating"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/393
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770"
     
     SubClassOf: 
         OEO_00020073
@@ -9811,6 +9811,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/770",
 Class: OEO_00020085
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy is an energy that has renewable origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbare Energie"@de,
+        rdfs:label "renewable energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
 
@@ -9819,10 +9822,7 @@ issue:https://github.com/OpenEnergyPlatform/ontology/issues/1423
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1437
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy is an energy that has renewable origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbare Energie"@de,
-        rdfs:label "renewable energy"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00000150
@@ -9838,10 +9838,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020086
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy carrier disposition is an energy carrier disposition of an material entity that contains renewable energy.",
-        rdfs:label "renewable energy carrier disposition"@en
+        rdfs:label "renewable energy carrier disposition"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861"
     
     SubClassOf: 
         OEO_00000151
@@ -9850,10 +9850,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020087
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Natural hydro energy is hydro energy collected from the natural water cycle (rainwater, melted snow and ice).",
-        rdfs:label "natural hydro energy"@en
+        rdfs:label "natural hydro energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861"
     
     SubClassOf: 
         OEO_00000218,
@@ -9864,10 +9864,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020088
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Pumped hydro energy is hydro energy that results from a water flow of pumped water.",
-        rdfs:label "pumped hydro energy"@en
+        rdfs:label "pumped hydro energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/741
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861"
     
     SubClassOf: 
         OEO_00000218,
@@ -9878,6 +9878,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861",
 Class: OEO_00020102
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation unit is an artificial object that transforms, changes or transfers a certain type of energy.",
+        rdfs:label "energy transformation unit"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895
 
@@ -9886,30 +9888,28 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transformation unit is an artificial object that transforms, changes or transfers a certain type of energy.",
-        rdfs:label "energy transformation unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000061,
-        OEO_00010235 some OEO_00010114,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/980
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1010"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000011,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020003,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020104
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020104,
+        OEO_00010235 some OEO_00010114
     
     
 Class: OEO_00020103
 
     Annotations: 
-        OEO_00020426 "class added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy transfer is an energy transformation in form of a spatial transmission, that does not change the types of energies, apart from losses, e.g. waste heat.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Energieübertragung"@de,
-        rdfs:label "energy transfer"@en
+        rdfs:label "energy transfer"@en,
+        OEO_00020426 "class added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/465
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895"
     
     SubClassOf: 
         OEO_00020003
@@ -9918,6 +9918,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/895",
 Class: OEO_00020104
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An outage is a process during which an artificial object cannot perform or operate.",
+        rdfs:label "outage"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897
 
@@ -9926,9 +9928,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An outage is a process during which an artificial object cannot perform or operate.",
-        rdfs:label "outage"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -9938,10 +9938,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020105
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A forced outage is an outage of an artificial object caused by a failure.",
-        rdfs:label "forced outage"@en
+        rdfs:label "forced outage"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897"
     
     SubClassOf: 
         OEO_00020104
@@ -9953,11 +9953,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
 Class: OEO_00020106
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A planned outage is an outage during which an artificial object is being maintained.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "geplante Abschaltung"@de,
-        rdfs:label "planned outage"@en
+        rdfs:label "planned outage"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/887
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897"
     
     SubClassOf: 
         OEO_00020104
@@ -9969,14 +9969,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897",
 Class: OEO_00020107
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Curtailment is a process in which a power generating unit is forced to reduce its output, in order to balance energy supply and demand or due to transmission constraints.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Abregelung"@de,
+        rdfs:label "curtailment"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/888
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/897
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Curtailment is a process in which a power generating unit is forced to reduce its output, in order to balance energy supply and demand or due to transmission constraints.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Abregelung"@de,
-        rdfs:label "curtailment"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -9986,6 +9986,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020136
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement is a two-dimensional spatial region that covers the area needed by an object or object aggregate.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Flächenbedarf"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Platzbedarf"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Raumbedarf"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "land use"@en,
+        rdfs:label "space requirement"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
 
@@ -9994,13 +10000,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1051
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement is a two-dimensional spatial region that covers the area needed by an object or object aggregate.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Flächenbedarf"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Platzbedarf"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Raumbedarf"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "land use"@en,
-        rdfs:label "space requirement"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000009>
@@ -10009,10 +10009,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020137
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An operational space requirement is space requirement that covers the area needed by an artificial object in order to operate properly.",
-        rdfs:label "operational space requirement"@en
+        rdfs:label "operational space requirement"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933"
     
     SubClassOf: 
         OEO_00020136
@@ -10021,10 +10021,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00020139
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A space requirement for construction is space requirement of an artificial object that covers the area needed in order to construct an artificial object.",
-        rdfs:label "space requirement for construction"@en
+        rdfs:label "space requirement for construction"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933"
     
     SubClassOf: 
         OEO_00020136
@@ -10033,14 +10033,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00020140
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An area per power unit is a unit which is a measure for an area per nameplate capacity.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Fläche pro Leistungseinheit"@de,
+        rdfs:label "area per power unit"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/930
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area per power unit is a unit which is a measure for an area per nameplate capacity.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Fläche pro Leistungseinheit"@de,
-        rdfs:label "area per power unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000000>
@@ -10049,12 +10049,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020141
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A specific space requirement is a quantity value that indicates a certain space requirement per nameplate capacity.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "spezifischer Flächenbedarf"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "spezifischer Raumbedarf"@de,
-        rdfs:label "specific space requirement"@en
+        rdfs:label "specific space requirement"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/899
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933"
     
     SubClassOf: 
         OEO_00000350,
@@ -10064,16 +10064,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933",
 Class: OEO_00020142
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An area unit which is equal to one million square meters or 10^[6] m^[2].",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Quadratkilometer"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "km^[2]",
         <http://purl.obolibrary.org/obo/IAO_0000118> "square km"@en,
-        rdfs:label "square kilometer"@en
+        rdfs:label "square kilometer"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000047>
@@ -10082,6 +10082,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020143
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Flächenwert"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "area quantity value"@en,
+        rdfs:label "area value"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/889
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/933
 
@@ -10091,22 +10095,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 restructuring of quantity values
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1848
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1851",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An area value is a quantity value indicating the size of a two-dimensional spatial region.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Flächenwert"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "area quantity value"@en,
-        rdfs:label "area value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1851"
     
     SubClassOf: 
         OEO_00000350,
+        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000009>,
         OEO_00020056 some OEO_00340068,
-        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000047>,
-        <http://purl.obolibrary.org/obo/IAO_0000136> some <http://purl.obolibrary.org/obo/BFO_0000009>
+        OEO_00040010 some <http://purl.obolibrary.org/obo/UO_0000047>
     
     
 Class: OEO_00020144
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Rotor diameter is a quality of a wind energy converting unit that measures the diameter of the wind rotor.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Rotordurchmesser"@de,
+        rdfs:label "rotor diameter"@en,
         OEO_00020426 "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/892
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/949
@@ -10117,21 +10120,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Rotor diameter is a quality of a wind energy converting unit that measures the diameter of the wind rotor.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Rotordurchmesser"@de,
-        rdfs:label "rotor diameter"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140001,
         <http://purl.obolibrary.org/obo/RO_0000052> some 
-            (OEO_00000044 or OEO_00000448)
+            (OEO_00000044 or OEO_00000448),
+        OEO_00140002 some OEO_00140001
     
     
 Class: OEO_00020147
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Conventional is an origin of energies that don't replenish when transformed / consumed.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "konventionell"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "non-renewable"@en,
+        rdfs:label "conventional"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
 
@@ -10141,11 +10145,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Conventional is an origin of energies that don't replenish when transformed / consumed.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "konventionell"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "non-renewable"@en,
-        rdfs:label "conventional"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00000316,
@@ -10161,10 +10161,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
 Class: OEO_00020148
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A conventional energy carrier disposition is an energy carrier disposition of a material entity that contains non-renewable energy.",
-        rdfs:label "conventional energy carrier disposition"@en
+        rdfs:label "conventional energy carrier disposition"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955"
     
     SubClassOf: 
         OEO_00000151
@@ -10173,6 +10173,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955",
 Class: OEO_00020149
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil energy is chemical energy that is stored in fossil combustion fuels and thus has a conventional origin.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "fossile Energie"@de,
+        rdfs:label "fossil energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/833
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/955
 
@@ -10182,15 +10185,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1185
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil energy is chemical energy that is stored in fossil combustion fuels and thus has a conventional origin.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "fossile Energie"@de,
-        rdfs:label "fossil energy"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     EquivalentTo: 
         OEO_00000007
-         and (OEO_00000530 some OEO_00020147)
          and (<http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000014)
+         and (OEO_00000530 some OEO_00020147)
     
     SubClassOf: 
         OEO_00000007
@@ -10202,14 +10202,14 @@ Class: OEO_00020166
 Class: OEO_00020175
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A life time is a time span of an artificial object that measures the time during which the artificial object exists.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Lebensdauer"@de,
+        rdfs:label "life time"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A life time is a time span of an artificial object that measures the time during which the artificial object exists.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Lebensdauer"@de,
-        rdfs:label "life time"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00030035,
@@ -10219,14 +10219,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020176
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A construction time is a time span that measures the time that is needed to construct an artificial object.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Bauzeit"@de,
+        rdfs:label "construction time"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A construction time is a time span that measures the time that is needed to construct an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Bauzeit"@de,
-        rdfs:label "construction time"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00030035,
@@ -10236,14 +10236,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020177
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning time is a time span that measures the time that is needed to decommission an artificial object.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Stilllegungszeitraum"@de,
+        rdfs:label "decommissioning time"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A decommissioning time is a time span that measures the time that is needed to decommission an artificial object.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Stilllegungszeitraum"@de,
-        rdfs:label "decommissioning time"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00030035,
@@ -10253,13 +10253,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020178
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational life time is the lifetime of an artificial object. It is measured from the end of construction time to the start of decommissioning time.",
+        rdfs:label "operational life time"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/894
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1026
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An operational life time is the lifetime of an artificial object. It is measured from the end of construction time to the start of decommissioning time.",
-        rdfs:label "operational life time"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00020175
@@ -10268,13 +10268,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020196
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fissile material entity is a material entity that has the disposition to carry nuclear (binding) energy.",
+        rdfs:label "fissile material entity"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1159
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1190
 
 Fix spelling of label:
-https://github.com/OpenEnergyPlatform/ontology/pull/1196",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fissile material entity is a material entity that has the disposition to carry nuclear (binding) energy.",
-        rdfs:label "fissile material entity"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1196"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000040>
@@ -10287,11 +10287,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1196",
 Class: OEO_00020197
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tangential proper part is a fiat object part of an entity which shares a boundary with that entity.",
         <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Region_connection_calculus",
-        rdfs:label "tangential proper part"@en
+        rdfs:label "tangential proper part"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000024>
@@ -10300,11 +10300,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
 Class: OEO_00020198
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A surface is a tangential proper part of an object that extends in two dimensions.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Oberfläche"@de,
-        rdfs:label "surface"@en
+        rdfs:label "surface"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209"
     
     SubClassOf: 
         OEO_00020197,
@@ -10314,10 +10314,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
 Class: OEO_00020199
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar radiation receiving surface is a surface that is receiving solar energy via solar radiation.",
-        rdfs:label "solar radiation receiving surface"@en
+        rdfs:label "solar radiation receiving surface"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209"
     
     EquivalentTo: 
         OEO_00020198
@@ -10330,13 +10330,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1209",
 Class: OEO_00020200
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar receiving object is an artificial object that has a solar radiation receiving surface as part.",
+        rdfs:label "solar receiving object"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1074
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1228
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A solar receiving object is an artificial object that has a solar radiation receiving surface as part.",
-        rdfs:label "solar receiving object"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359"
     
     EquivalentTo: 
         OEO_00000061
@@ -10356,13 +10356,13 @@ Class: OEO_00020202
 Class: OEO_00020204
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy amount value is an energy amount value that measures a quantity of electrical energy.",
+        rdfs:label "electrical energy amount value"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy amount value is an energy amount value that measures a quantity of electrical energy.",
-        rdfs:label "electrical energy amount value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00050019
@@ -10371,6 +10371,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020205
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity import value is an electrical energy amount value that measures the import of electrical energy."@en,
+        rdfs:label "electricity import value"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
 rework module structure 
@@ -10379,9 +10381,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 Fix definition:
 https://github.com/OpenEnergyPlatform/ontology/issues/1863
-https://github.com/OpenEnergyPlatform/ontology/pull/1864",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity import value is an electrical energy amount value that measures the import of electrical energy."@en,
-        rdfs:label "electricity import value"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1864"
     
     SubClassOf: 
         OEO_00020204,
@@ -10391,6 +10391,8 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1864",
 Class: OEO_00020206
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export value is an electrical energy amount value that measures the export of electrical energy."@en,
+        rdfs:label "electricity export value"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
 rework module structure 
@@ -10399,9 +10401,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 Fix definition:
 https://github.com/OpenEnergyPlatform/ontology/issues/1863
-https://github.com/OpenEnergyPlatform/ontology/pull/1864",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity export value is an electrical energy amount value that measures the export of electrical energy."@en,
-        rdfs:label "electricity export value"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1864"
     
     SubClassOf: 
         OEO_00020204,
@@ -10411,6 +10411,9 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1864",
 Class: OEO_00020207
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Stromimport"@de,
+        rdfs:label "electricity import"@en,
         OEO_00020426 "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
@@ -10420,20 +10423,20 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity import is the import of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Stromimport"@de,
-        rdfs:label "electricity import"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00020201,
-        OEO_00140002 some OEO_00020205,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139,
+        OEO_00140002 some OEO_00020205
     
     
 Class: OEO_00020208
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Stromexport"@de,
+        rdfs:label "electricity export"@en,
         OEO_00020426 "add class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/998
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221
@@ -10443,26 +10446,23 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity export is the export of electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Stromexport"@de,
-        rdfs:label "electricity export"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00020202,
-        OEO_00140002 some OEO_00020206,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000139,
+        OEO_00140002 some OEO_00020206
     
     
 Class: OEO_00020210
 
     Annotations: 
-        OEO_00020426 "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sirup is a portion of matter that consists mainly of water and sugar. It has a liquid state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Sirup"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "sirop"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "syrup"@en,
-        rdfs:label "sirup"@en
+        rdfs:label "sirup"@en,
+        OEO_00020426 "pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1221"
     
     SubClassOf: 
         OEO_00000331,
@@ -10473,10 +10473,10 @@ Class: OEO_00020210
 Class: OEO_00020249
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1495
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed-air energy storage unit is an energy storage unit that uses compressed air.",
-        rdfs:label "compressed-air energy storage unit"@en
+        rdfs:label "compressed-air energy storage unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1495
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499"
     
     SubClassOf: 
         OEO_00000399,
@@ -10486,12 +10486,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499",
 Class: OEO_00020251
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1528
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1541",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Propulsion is an energy transformation that converts other forms of energy to kinetic energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Antrieb"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "energy-to-motion-process"@en,
-        rdfs:label "propulsion"@en
+        rdfs:label "propulsion"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1528
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1541"
     
     EquivalentTo: 
         OEO_00020003
@@ -10504,6 +10504,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1541",
 Class: OEO_00020252
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things)."@en,
+        rdfs:label "climate system"@en,
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001364>,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1540
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1542
 
@@ -10516,10 +10519,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate system is a system that has five interacting components: the atmosphere (air), the hydrosphere (water), the cryosphere (ice and permafrost), the lithosphere (earth's upper rocky layer) and the biosphere (living things)."@en,
-        rdfs:label "climate system"@en,
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001364>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/RO_0002577>
@@ -10528,15 +10528,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
 Class: OEO_00020254
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy share is a process attribute that indicates the fraction of electrical energy related to the total energy of an energy generation or consumption process.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "degree of electrification",
+        rdfs:label "electrical energy share"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy share is a process attribute that indicates the fraction of electrical energy related to the total energy of an energy generation or consumption process.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "degree of electrification",
-        rdfs:label "electrical energy share"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
     SubClassOf: 
         OEO_00030019,
@@ -10546,11 +10546,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00020255
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy share value is a fraction value that quantifies a share of renewable energy (RE-share)",
         <http://purl.obolibrary.org/obo/IAO_0000118> "RE share value",
-        rdfs:label "renewable energy share value"@en
+        rdfs:label "renewable energy share value"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561"
     
     SubClassOf: 
         OEO_00140127,
@@ -10560,11 +10560,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561",
 Class: OEO_00020256
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy share value is a fraction value that quantifies the share of electrical energy (degree of electrification).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "renewable energy share value",
-        rdfs:label "electrical energy share value"@en
+        rdfs:label "electrical energy share value"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561"
     
     SubClassOf: 
         OEO_00140127,
@@ -10574,14 +10574,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561",
 Class: OEO_00020264
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A material transformation is a transformation in which one or more input material entities are, at least partially, physically changed and result in output material entites."@en,
+        rdfs:label "material transformation"@en,
         OEO_00020426 "class added:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A material transformation is a transformation in which one or more input material entities are, at least partially, physically changed and result in output material entites."@en,
-        rdfs:label "material transformation"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en
     
     EquivalentTo: 
         OEO_00000419
@@ -10595,13 +10595,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
 Class: OEO_00020267
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy technology is a technology that describes how to combine energy transformation units, energy transformations, energy carriers and energy in a specific way.",
+        rdfs:label "energy technology"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1591
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy technology is a technology that describes how to combine energy transformation units, energy transformations, energy carriers and energy in a specific way.",
-        rdfs:label "energy technology"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000407,
@@ -10613,10 +10613,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00020306
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1610",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal heat technology is a heat generation technology that describes how to combine geothermal heat units, geothermal heat transfer processes, energy carriers and energy in a specific way.",
-        rdfs:label "geothermal heat technology"@en
+        rdfs:label "geothermal heat technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1610"
     
     SubClassOf: 
         OEO_00020308,
@@ -10628,10 +10628,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1610",
 Class: OEO_00020307
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1610",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar thermal heat technology is a heat generation technology that describes how to combine solar heat units, solar thermal energy transformation processes, energy carriers and energy in a specific way.",
-        rdfs:label "solar thermal heat technology"@en
+        rdfs:label "solar thermal heat technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1610"
     
     SubClassOf: 
         OEO_00020308,
@@ -10643,10 +10643,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1610",
 Class: OEO_00020308
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1610",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generation technology is an energy technology that describes how to combine heat generating units, heat generation processes, energy carriers and energy in a specific way.",
-        rdfs:label "heat generation technology"@en
+        rdfs:label "heat generation technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1610"
     
     SubClassOf: 
         OEO_00020267,
@@ -10658,13 +10658,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1610",
 Class: OEO_00020347
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel technology is an energy technology that describes how to combine power-to-fuel systems in power-to-fuel processes.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "p2x technology",
         <http://purl.obolibrary.org/obo/IAO_0000118> "power-to-x technology",
         <http://purl.obolibrary.org/obo/IAO_0000118> "ptx technology",
-        rdfs:label "power-to-fuel technology"@en
+        rdfs:label "power-to-fuel technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647"
     
     SubClassOf: 
         OEO_00020267,
@@ -10676,10 +10676,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
 Class: OEO_00020348
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-gas technology is a power-to-fuel technology that describes how to combine power-to-gas systems in power-to-gas processes.",
-        rdfs:label "power-to-gas technology"@en
+        rdfs:label "power-to-gas technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647"
     
     SubClassOf: 
         OEO_00020347,
@@ -10691,10 +10691,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
 Class: OEO_00020349
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia technology is an power-to-gas technology that describes how to combine power-to-ammonia systems in power-to-ammonia processes.",
-        rdfs:label "power-to-ammonia technology"@en
+        rdfs:label "power-to-ammonia technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647"
     
     SubClassOf: 
         OEO_00020348,
@@ -10706,10 +10706,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
 Class: OEO_00020350
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-methane technology is an power-to-gas technology that describes how to combine power-to-methane systems in power-to-methane processes.",
-        rdfs:label "power-to-methane technology"@en
+        rdfs:label "power-to-methane technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647"
     
     SubClassOf: 
         OEO_00020348,
@@ -10721,10 +10721,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
 Class: OEO_00020351
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid technology is an power-to-fuel technology that describes how to combine power-to-liquid systems in power-to-liquid processes.",
-        rdfs:label "power-to-liquid technology"@en
+        rdfs:label "power-to-liquid technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647"
     
     SubClassOf: 
         OEO_00020347,
@@ -10736,11 +10736,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1647",
 Class: OEO_00020362
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy storage object is an energy storage object that has the function to store electrical energy.",
         rdfs:comment "The electrical energy storage object is being charged with electrical energy and releases electrical energy during the decharging process. The stored energy within the object may appear in a different form of energy, though.",
-        rdfs:label "electrical energy storage object"@en
+        rdfs:label "electrical energy storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     EquivalentTo: 
         OEO_00000159
@@ -10753,10 +10753,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00020363
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical energy storage object is an energy storage object that has the function to store chemical energy.",
-        rdfs:label "chemical energy storage object"@en
+        rdfs:label "chemical energy storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     EquivalentTo: 
         OEO_00000159
@@ -10769,11 +10769,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00020364
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A kinetic energy storage object is an energy storage object that has the function to store kinetic energy.",
         rdfs:comment "The kinetic energy storage object is being charged with kinetic energy and releases kinetic energy during the decharging process. The stored energy within the object may appear in a different form of energy, though.",
-        rdfs:label "kinetic energy storage object"@en
+        rdfs:label "kinetic energy storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     EquivalentTo: 
         OEO_00000159
@@ -10786,11 +10786,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00020365
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A thermal energy storage object is an energy storage object that has the function to store thermal energy.",
         rdfs:comment "The thermal energy storage object is being charged with thermal energy and releases thermal energy during the decharging process. The stored energy within the object may appear in a different form of energy, though.",
-        rdfs:label "thermal energy storage object"@en
+        rdfs:label "thermal energy storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     EquivalentTo: 
         OEO_00000159
@@ -10803,10 +10803,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00020366
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage technology is an energy technology that describes how to combine energy storage objects and energy carriers in charging and decharging processes for the purpose of temporarily storing energy.",
-        rdfs:label "energy storage technology"@en
+        rdfs:label "energy storage technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     SubClassOf: 
         OEO_00020267,
@@ -10818,10 +10818,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00020367
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical energy storage technology is an energy storage technology that describes how to combine electrical energy storage objects and electrical energy in charging and decharging processes.",
-        rdfs:label "electrical energy storage technology"@en
+        rdfs:label "electrical energy storage technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     SubClassOf: 
         OEO_00020366,
@@ -10833,10 +10833,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00020368
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An kinetic energy storage technology is an energy storage technology that describes how to combine kinetic energy storage objects and kinetic energy in charging and decharging processes.",
-        rdfs:label "kinetic energy storage technology"@en
+        rdfs:label "kinetic energy storage technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     SubClassOf: 
         OEO_00020366,
@@ -10848,10 +10848,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00020369
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An thermal energy storage technology is an energy storage technology that describes how to combine thermal energy storage objects and thermal energy in charging and decharging processes.",
-        rdfs:label "thermal energy storage technology"@en
+        rdfs:label "thermal energy storage technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     SubClassOf: 
         OEO_00020366,
@@ -10863,10 +10863,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00020370
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An chemical energy storage technology is an energy storage technology that describes how to combine chemical energy storage objects and chemical energy in charging and decharging processes.",
-        rdfs:label "chemical energy storage technology"@en
+        rdfs:label "chemical energy storage technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     SubClassOf: 
         OEO_00020366,
@@ -10878,11 +10878,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00020371
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A potential energy storage object is an energy storage object that has the function to store potential energy.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This object was introduce for the sake of completeness, but there is no actual use case seen at the moment.",
-        rdfs:label "potential energy storage object"@en
+        rdfs:label "potential energy storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     EquivalentTo: 
         OEO_00000159
@@ -10895,11 +10895,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00020372
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An potential energy storage technology is an energy storage technology that describes how to combine potential energy storage objects and potential energy in charging and decharging processes.",
         <http://purl.obolibrary.org/obo/IAO_0000116> "This technology was introduce for the sake of completeness, but there is no actual use case seen at the moment.",
-        rdfs:label "potential energy storage technology"@en
+        rdfs:label "potential energy storage technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1572
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728"
     
     SubClassOf: 
         OEO_00020366,
@@ -10911,11 +10911,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1728",
 Class: OEO_00020407
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1521
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1842",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sector coupling technology is a technology that intends to connect processes from the electricity, heat, mobility or industrial sectors, as well as their infrastructures.",
         <http://purl.obolibrary.org/obo/IAO_0000600> "The aim of sector coupling is usually an optimisation of an energy system (e.g. with respect to cost, environmental impact, sustainability and decarbonisation) by establishing energy flows across sectorial borders",
-        rdfs:label "sector coupling technology"
+        rdfs:label "sector coupling technology",
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1521
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1842"
     
     SubClassOf: 
         OEO_00000407,
@@ -10927,15 +10927,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1842",
 Class: OEO_00020408
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Sector coupling is a process of connecting processes from the electricity, heat, mobility or industrial sectors as well as their infrastructures.",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "The aim of sector coupling is usually an optimisation of an energy system (e.g. with respect to cost, environmental impact, sustainability and decarbonisation) by establishing energy flows across sectorial borders",
+        rdfs:label "sector coupling",
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1521
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1842
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Sector coupling is a process of connecting processes from the electricity, heat, mobility or industrial sectors as well as their infrastructures.",
-        <http://purl.obolibrary.org/obo/IAO_0000600> "The aim of sector coupling is usually an optimisation of an energy system (e.g. with respect to cost, environmental impact, sustainability and decarbonisation) by establishing energy flows across sectorial borders",
-        rdfs:label "sector coupling"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -10944,10 +10944,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00020410
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1683
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1843",
         <http://purl.obolibrary.org/obo/IAO_0000115> "System robustness is a disposition of a system that is designed or evolved in such a way as to be resistant to total failure despite partial damage or external changes.",
-        rdfs:label "system robustness"
+        rdfs:label "system robustness",
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1683
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1843"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>
@@ -10956,6 +10956,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1843",
 Class: OEO_00030000
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthropogenic is an origin of portions of matter or energies created by human activity.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "anthropogen"@de,
+        rdfs:label "anthropogenic"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
 
@@ -10969,10 +10972,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Anthropogenic is an origin of portions of matter or energies created by human activity.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "anthropogen"@de,
-        rdfs:label "anthropogenic"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00000316,
@@ -10983,6 +10983,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00030001
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogenic is an origin of portions of matter made by or produced from life forms.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "biogen"@de,
+        rdfs:label "biogenic"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
 
@@ -10992,10 +10995,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Biogenic is an origin of portions of matter made by or produced from life forms.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "biogen"@de,
-        rdfs:label "biogenic"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00000316,
@@ -11008,6 +11008,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00030002
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil is a geogenic origin of portions of matter created from organic material by geological processes lasting thousands or millions of years.",
+        <http://purl.obolibrary.org/obo/IAO_0000116> "In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "fossil"@de,
+        rdfs:label "fossil"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
 
@@ -11033,11 +11037,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fossil is a geogenic origin of portions of matter created from organic material by geological processes lasting thousands or millions of years.",
-        <http://purl.obolibrary.org/obo/IAO_0000116> "In real world, fossils are from biogenic origin some thousands or millions of years ago. However, this is irrelevant in the energy modelling domain.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "fossil"@de,
-        rdfs:label "fossil"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00030003,
@@ -11050,6 +11050,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00030003
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Geogenic is an origin of portions of matter or energies that are the result of geological processes.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "geogen"@de,
+        rdfs:label "geogenic"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
 
@@ -11071,10 +11074,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Geogenic is an origin of portions of matter or energies that are the result of geological processes.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "geogen"@de,
-        rdfs:label "geogenic"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00000316,
@@ -11085,6 +11085,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00030004
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbar"@de,
+        rdfs:label "renewable"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/397
@@ -11109,10 +11112,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Renewable is an origin of energies that replenish on a human time scale.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbar"@de,
-        rdfs:label "renewable"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00000316,
@@ -11128,6 +11128,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1048"
 Class: OEO_00030005
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic is an anthropogenic origin of portions of matter created artificially by a chemical process.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetisch"@de,
+        rdfs:label "synthetic"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/108
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/130
 
@@ -11141,10 +11144,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1192
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Synthetic is an anthropogenic origin of portions of matter created artificially by a chemical process.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "synthetisch"@de,
-        rdfs:label "synthetic"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00030000,
@@ -11160,6 +11160,10 @@ Class: OEO_00030022
 Class: OEO_00030024
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a supply system of spatially extended linked energy sources and sinks.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Energiesystem"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy supply system"@en,
+        rdfs:label "energy system"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
 
@@ -11172,11 +11176,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy system is a supply system of spatially extended linked energy sources and sinks.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Energiesystem"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy supply system"@en,
-        rdfs:label "energy system"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00030025
@@ -11185,6 +11185,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030025
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Versorgungssystem"@de,
+        rdfs:label "supply system"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/432
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/493
 
@@ -11193,10 +11196,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1329
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1615
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A supply system is a system that connects producers and consumers.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Versorgungssystem"@de,
-        rdfs:label "supply system"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/RO_0002577>
@@ -11205,6 +11205,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00030026
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy production is a production that prepares raw material for its use as primary energy carrier."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "primary production of energy",
+        rdfs:label "primary energy production"@en,
         OEO_00020426 "add eurostat alternative term:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
 pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
@@ -11217,10 +11220,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy production is a production that prepares raw material for its use as primary energy carrier."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "primary production of energy",
-        rdfs:label "primary energy production"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498"
     
     SubClassOf: 
         OEO_00240003,
@@ -11231,13 +11231,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
 Class: OEO_00030027
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier mining is a primary energy production that recovers non-renewable energy carriers from its natural site."@en,
+        rdfs:label "primary energy carrier mining"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier mining is a primary energy production that recovers non-renewable energy carriers from its natural site."@en,
-        rdfs:label "primary energy carrier mining"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498"
     
     SubClassOf: 
         OEO_00030026
@@ -11246,13 +11246,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
 Class: OEO_00030028
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier harvest is a primary energy production that collects solid biomass from its natural site."@en,
+        rdfs:label "primary energy carrier harvest"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/77
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier harvest is a primary energy production that collects solid biomass from its natural site."@en,
-        rdfs:label "primary energy carrier harvest"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/498"
     
     SubClassOf: 
         OEO_00030026
@@ -11264,31 +11264,34 @@ Class: OEO_00030035
 Class: OEO_00050000
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/534
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589
-
-Relabel and redefine:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A manufacturing process is a process that produces artificial objects or object aggregates that are economic goods. It involves several subprocesses, which are energy transformations and material transformations amongst others."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Herstellungsprozess"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "industrial process"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "industrieller Prozess"@de,
         rdfs:label "manufacturing process"@en,
-        skos:closeMatch <https://spec.industrialontologies.org/ontology/core/Core/ManufacturingProcess>
+        skos:closeMatch <https://spec.industrialontologies.org/ontology/core/Core/ManufacturingProcess>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/534
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/589
+
+Relabel and redefine:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1726
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
         (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020003)
          and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020264),
         <http://purl.obolibrary.org/obo/RO_0002234> some 
-            ((OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000027>)
+            ((<http://purl.obolibrary.org/obo/BFO_0000027> or OEO_00000061)
              and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117))
     
     
 Class: OEO_00050001
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel-powered electricity generation process is an electricity generation process that converts chemical energy from a combustion fuel to electrical energy. It causes some emission.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "fuel-powered electricity generation",
+        rdfs:label "fuel-powered electricity generation process"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/582
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/592
 
@@ -11298,10 +11301,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1240
 
 Relabel and add old label as alternative term:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel-powered electricity generation process is an electricity generation process that converts chemical energy from a combustion fuel to electrical energy. It causes some emission.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "fuel-powered electricity generation",
-        rdfs:label "fuel-powered electricity generation process"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562"
     
     EquivalentTo: 
         OEO_00240014
@@ -11309,23 +11309,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
     
     SubClassOf: 
         OEO_00240014,
-        OEO_00000500 some OEO_00000148,
-        OEO_00000533 some OEO_00000331,
-        OEO_00010234 some OEO_00000007,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000174,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000175,
-        <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147
+        <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147,
+        OEO_00000500 some OEO_00000148,
+        OEO_00000533 some OEO_00000331,
+        OEO_00010234 some OEO_00000007
     
     
 Class: OEO_00050002
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kilojoule"@de,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "kJ",
-        rdfs:label "kilojoule"@en
+        rdfs:label "kilojoule"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -11334,12 +11334,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050003
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 1,000,000 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Megajoule"@de,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MJ",
-        rdfs:label "megajoule"@en
+        rdfs:label "megajoule"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -11348,12 +11348,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050004
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^9 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gigajoule"@de,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GJ",
-        rdfs:label "gigajoule"@en
+        rdfs:label "gigajoule"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -11362,12 +11362,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050005
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^12 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Terajoule"@de,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TJ",
-        rdfs:label "terajoule"@en
+        rdfs:label "terajoule"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -11376,12 +11376,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050006
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^15 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Petajoule"@de,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PJ",
-        rdfs:label "petajoule"@en
+        rdfs:label "petajoule"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -11390,12 +11390,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050007
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy unit which is equal to 10^18 joules.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Exajoule"@de,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "EJ",
-        rdfs:label "exajoule"@en
+        rdfs:label "exajoule"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -11404,16 +11404,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608",
 Class: OEO_00050008
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A megawatt-hour is a watt-hour based unit which is equal to 10^6 watt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Megawattstunde"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "megawatt hours"@en,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "MWh",
-        rdfs:label "megawatt-hour"@en
+        rdfs:label "megawatt-hour"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1830
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/UO_1000223>
@@ -11427,16 +11427,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845",
 Class: OEO_00050009
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A terawatt-hour is a watt-hour based unit which is equal to 10^12 watt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Terawatstunde"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "terawatt hours"@en,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "TWh",
-        rdfs:label "terawatt-hour"@en
+        rdfs:label "terawatt-hour"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1830
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/UO_1000223>
@@ -11450,16 +11450,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845",
 Class: OEO_00050010
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A petawatt-hour is a watt-hour based unit which is equal to 10^15 watt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Petawattstunde"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "petawatt hours"@en,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "PWh",
-        rdfs:label "petawatt-hour"@en
+        rdfs:label "petawatt-hour"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1830
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/UO_1000223>
@@ -11473,6 +11473,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845",
 Class: OEO_00050011
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gigawatt-hour is a watt-hour based unit which is equal to 10^9 watt-hours.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Gigawattstunde"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gigawatt hours"@en,
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GWh",
+        rdfs:label "gigawatt-hour"@en,
         OEO_00020426 "add eurostat alternative term:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/920
 pull: https://github.com/OpenEnergyPlatform/ontology/pull/924
@@ -11481,12 +11486,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/606
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/608
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1830
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gigawatt-hour is a watt-hour based unit which is equal to 10^9 watt-hours.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Gigawattstunde"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "gigawatt hours"@en,
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "GWh",
-        rdfs:label "gigawatt-hour"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/UO_1000223>
@@ -11500,6 +11500,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1845",
 Class: OEO_00050016
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy consumption value is an energy consumption value expressing the magnitude of the energy delivered to and consumed by end users."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Endenergieverbrauch"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "final energy consumption"@en,
+        rdfs:label "final energy consumption value"@en,
         OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
@@ -11514,11 +11518,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy consumption value is an energy consumption value expressing the magnitude of the energy delivered to and consumed by end users."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Endenergieverbrauch"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "final energy consumption"@en,
-        rdfs:label "final energy consumption value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065"
     
     EquivalentTo: 
         OEO_00240019
@@ -11531,19 +11531,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
 Class: OEO_00050017
 
     Annotations: 
-        OEO_00020426 "become a subclass of quantity value:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
-
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
-
-improve definition:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gross inland energy consumption value is an energy consumption value expressing the magnitude of the total consumption of energy in a spatial region (e.g. a country)."@en,
         <http://purl.obolibrary.org/obo/IAO_0000116> "Gross inland energy consumption represents the quantity of energy necessary to satisfy inland consumption of the spatial region (e.g. a country) under consideration.
 
@@ -11559,7 +11546,20 @@ Gross inland energy consumption does not include energy (fuel oil) provided to i
         <http://purl.obolibrary.org/obo/IAO_0000118> "primary energy consumption including non-energy use of energy carriers"@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
 https://ec.europa.eu/eurostat/statistics-explained/index.php/Glossary:Gross_inland_energy_consumption"@en,
-        rdfs:label "gross inland energy consumption value"@en
+        rdfs:label "gross inland energy consumption value"@en,
+        OEO_00020426 "become a subclass of quantity value:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
+
+improve definition:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1129
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1306"@en
     
     SubClassOf: 
         OEO_00240019,
@@ -11569,6 +11569,13 @@ https://ec.europa.eu/eurostat/statistics-explained/index.php/Glossary:Gross_inla
 Class: OEO_00050018
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption value is an energy consumption value expressing the magnitude of the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Primärenergieverbrauch"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
+https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en,
+        rdfs:label "primary energy consumption value"@en,
         OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/709
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/719
@@ -11588,14 +11595,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy consumption value is an energy consumption value expressing the magnitude of the total consumption of energy in a spatial region excluding the non-energetic use of fuels."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Primary energy consumption covers consumption of the energy sector itself, losses during transformation (for example, from oil or gas into electricity) and distribution of energy, and the final consumption by end users. It excludes energy carriers used for non-energy purposes (such as petroleum not used not for combustion but for producing plastics)."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Primary energy consumption excluding non-energy use of energy carriers."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Primärenergieverbrauch"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Eurostat Energy Glossary
-https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Primary_energy_consumption"@en,
-        rdfs:label "primary energy consumption value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065"
     
     SubClassOf: 
         OEO_00240019,
@@ -11605,6 +11605,11 @@ https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Prim
 Class: OEO_00050019
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy value is a quantity value that has an energy unit as unit."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Energiemenge"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy amount value",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
+        rdfs:label "energy value"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/576
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/613
 moved to oeo-shared
@@ -11617,12 +11622,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 change label and add alternative label
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1865
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1941",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy value is a quantity value that has an energy unit as unit."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Energiemenge"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy amount value",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "energy quantity value",
-        rdfs:label "energy value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1941"
     
     SubClassOf: 
         OEO_00000350,
@@ -11632,34 +11632,34 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1941",
 Class: OEO_00050020
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam-electric process is an energy transformation that converts thermal energy to electrical energy. A steam turbine and an electro motive generator are participating in a steam-electric process."@en,
+        rdfs:label "steam-electric process"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/659
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/691
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A steam-electric process is an energy transformation that converts thermal energy to electrical energy. A steam turbine and an electro motive generator are participating in a steam-electric process."@en,
-        rdfs:label "steam-electric process"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en
     
     SubClassOf: 
         OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396,
         OEO_00010234 some OEO_00000207,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
-        OEO_00010235 some OEO_00000139,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396
+        OEO_00010235 some OEO_00000139
     
     
 Class: OEO_00090000
 
     Annotations: 
-        OEO_00020426 "Issue: https://github.com/OpenEnergyPlatform/ontology/pull/693
-Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/693",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A volumetric flow rate value is a quantity value that has a volumetric flow rate unit as unit.",
-        rdfs:label "volumetric flow rate value"@en
+        rdfs:label "volumetric flow rate value"@en,
+        OEO_00020426 "Issue: https://github.com/OpenEnergyPlatform/ontology/pull/693
+Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/693"
     
     SubClassOf: 
         OEO_00000350,
@@ -11669,11 +11669,11 @@ Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/693",
 Class: OEO_00110000
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid water is water that has a liquid state of matter."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "flüssiges Wasser"@de,
-        rdfs:label "liquid water"@en
+        rdfs:label "liquid water"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en
     
     SubClassOf: 
         OEO_00000441,
@@ -11684,15 +11684,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
 Class: OEO_00110001
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Steam is water that has a gaseous state of matter."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Dampf"@de,
+        rdfs:label "steam"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
 
 add axiom to secondary energy carrier disposition
 issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Steam is water that has a gaseous state of matter."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Dampf"@de,
-        rdfs:label "steam"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"@en
     
     SubClassOf: 
         OEO_00000441,
@@ -11703,26 +11703,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"@en,
 Class: OEO_00110002
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow is a process of liquid water moving."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserfluss"@de,
-        rdfs:label "water flow"@en
+        rdfs:label "water flow"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00000500 some OEO_00110003,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00110000
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00110000,
+        OEO_00000500 some OEO_00110003
     
     
 Class: OEO_00110003
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Water flow rate is the process attribute of water flow that quantifies the water volume per time unit."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserdurchflussrate"@de,
-        rdfs:label "water flow rate"@en
+        rdfs:label "water flow rate"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en
     
     SubClassOf: 
         OEO_00030019,
@@ -11732,15 +11732,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682"@en,
 Class: OEO_00110004
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy transformation is an energy transformation that converts hydro energy."@en,
+        rdfs:label "hydro energy transformation"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/702
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydro energy transformation is an energy transformation that converts hydro energy."@en,
-        rdfs:label "hydro energy transformation"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en
     
     SubClassOf: 
         OEO_00020003,
@@ -11750,14 +11750,14 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
 Class: OEO_00110005
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydroelectric energy transformation is a hydro energy transformation that converts hydro energy to electrical energy."@en,
+        rdfs:label "hydroelectric energy transformation"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/682
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydroelectric energy transformation is a hydro energy transformation that converts hydro energy to electrical energy."@en,
-        rdfs:label "hydroelectric energy transformation"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"@en
     
     SubClassOf: 
         OEO_00110004,
@@ -11770,6 +11770,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00140000
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hub height is a quality of a wind energy converting unit that measures the distance between surface and centre-line of the wind rotor.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Nabenhöhe"@de,
+        rdfs:label "hub height"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509
 
@@ -11779,24 +11782,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hub height is a quality of a wind energy converting unit that measures the distance between surface and centre-line of the wind rotor.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Nabenhöhe"@de,
-        rdfs:label "hub height"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140001,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000044
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000044,
+        OEO_00140002 some OEO_00140001
     
     
 Class: OEO_00140001
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Length value is a quantity value that has a length unit as unit.",
-        rdfs:label "length value"@en
+        rdfs:label "length value"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/505
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509"
     
     SubClassOf: 
         OEO_00000350,
@@ -11806,6 +11806,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/509",
 Class: OEO_00140003
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Transport"@de,
+        rdfs:label "transport"@en,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
+
+Convert to skos:closeMatch
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02000125>,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
 
@@ -11819,38 +11830,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1309
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Transport is the process of moving people or goods from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Transport"@de,
-        rdfs:label "transport"@en,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
-
-Convert to skos:closeMatch
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_02000125>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
-        OEO_00140002 some OEO_00320000,
         <http://purl.obolibrary.org/obo/RO_0000057> some 
-            (OEO_00000323 or OEO_00010116)
+            (OEO_00000323 or OEO_00010116),
+        OEO_00140002 some OEO_00320000
     
     
 Class: OEO_00140004
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "International transport is a transport process between different countries or within the same country via another country.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "internationaler Verkehr"@de,
+        rdfs:label "international transport"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "International transport is a transport process between different countries or within the same country via another country.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "internationaler Verkehr"@de,
-        rdfs:label "international transport"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00140003
@@ -11859,6 +11859,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140005
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Frachttransport"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Gütertransport"@de,
+        rdfs:label "freight transport"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
 
@@ -11868,11 +11872,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Freight transport is a transport process which moves goods from one place to another.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Frachttransport"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Gütertransport"@de,
-        rdfs:label "freight transport"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00140003,
@@ -11882,6 +11882,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140006
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A private transport is a passenger transport in which people use their own vehicle for movement e.g. bicycle, motorcycle and cars.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Individualverkehr"@de,
+        rdfs:label "private transport"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
 
@@ -11891,10 +11894,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A private transport is a passenger transport in which people use their own vehicle for movement e.g. bicycle, motorcycle and cars.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Individualverkehr"@de,
-        rdfs:label "private transport"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00010263
@@ -11903,6 +11903,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140007
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A public transport is a passenger transport in which a number of passengers share a common vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "öffentlicher Verkehr"@de,
+        rdfs:label "public transport"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/503
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/517
 
@@ -11912,10 +11915,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1234
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A public transport is a passenger transport in which a number of passengers share a common vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "öffentlicher Verkehr"@de,
-        rdfs:label "public transport"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00010263
@@ -11924,6 +11924,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140033
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "chemische Reaktion"@de,
+        rdfs:label "chemical reaction"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568
 
@@ -11937,10 +11940,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical reaction is a transformation that involves the interconversion of chemical species.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "chemische Reaktion"@de,
-        rdfs:label "chemical reaction"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000419,
@@ -11950,12 +11950,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140034
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A redox reaction is a chemical reaction in which the oxidation of one reactant is coupled to the reduction of a second reactant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Redoxreaktion"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "oxidation"@en,
-        rdfs:label "redox reaction"@en
+        rdfs:label "redox reaction"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568"
     
     SubClassOf: 
         OEO_00140033
@@ -11964,11 +11964,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140035
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Oxidation is a chemical reaction that describes the loss of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Oxidation"@de,
-        rdfs:label "oxidation"@en
+        rdfs:label "oxidation"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568"
     
     SubClassOf: 
         OEO_00140033
@@ -11977,11 +11977,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140036
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Reduction is a chemical reaction that describes the gain of electrons of an atom, an ion, or of certain atoms in a molecule and is a part of a redox reaction.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Reduktion"@de,
-        rdfs:label "reduction"@en
+        rdfs:label "reduction"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568"
     
     SubClassOf: 
         OEO_00140033
@@ -11990,11 +11990,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140037
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrochemical reaction is a chemical reaction that describes the overall reactions of individual redox reactions being separated but connected by an external electric circuit and an intervening electrolyte.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "elektrochemische Reaktion"@de,
-        rdfs:label "electrochemical reaction"@en
+        rdfs:label "electrochemical reaction"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568"
     
     SubClassOf: 
         OEO_00140033
@@ -12003,11 +12003,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140038
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion is an exothermic redox reaction between a fuel (the reductant) and an oxidant (usually atmospheric oxygen) which is initiated by a ignition source.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Verbrennung"@de,
-        rdfs:label "combustion"@en
+        rdfs:label "combustion"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/449
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568"
     
     SubClassOf: 
         OEO_00140034
@@ -12016,15 +12016,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/568",
 Class: OEO_00140039
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Verbrauch"@de,
+        rdfs:label "consumption"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Consumption is the process of using something and thereby reducing its amount.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Verbrauch"@de,
-        rdfs:label "consumption"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -12033,6 +12033,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140040
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Bedarf"@de,
+        rdfs:label "demand"@en,
         OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/140
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/569
@@ -12052,20 +12055,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A demand is a realizable entity that is characterised by a person, organisation or object needing it for a specific purpose.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Bedarf"@de,
-        rdfs:label "demand"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000017>,
         <http://purl.obolibrary.org/obo/RO_0000052> some 
-            (OEO_00030022 or <http://purl.obolibrary.org/obo/BFO_0000030>)
+            (<http://purl.obolibrary.org/obo/BFO_0000030> or OEO_00030022)
     
     
 Class: OEO_00140049
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Energieumwandlungseffizienz"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Wirkungsgrad"@de,
+        rdfs:label "energy conversion efficiency"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591
@@ -12078,11 +12082,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion efficiency is a process attribute describing the ratio between the input of an energy transformation and the outputs that are used.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Energieumwandlungseffizienz"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Wirkungsgrad"@de,
-        rdfs:label "energy conversion efficiency"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
     SubClassOf: 
         OEO_00030019,
@@ -12093,6 +12093,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00140050
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "efficiency",
+        rdfs:label "efficiency value"@en,
         OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591
@@ -12107,13 +12113,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An efficiency value is a quantity value stating the ratio between a process's inputs and the outputs that are used.",
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "efficiency",
-        rdfs:label "efficiency value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065"
     
     SubClassOf: 
         OEO_00000350,
@@ -12123,11 +12123,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
 Class: OEO_00140051
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A coefficient of performance value is a quantity value stating the ratio between the work input and the total output of an energy conversion process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Leistungszahl"@de,
-        rdfs:label "coefficient of performance value"@en
+        rdfs:label "coefficient of performance value"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591"
     
     SubClassOf: 
         OEO_00000350,
@@ -12138,10 +12138,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
 Class: OEO_00140052
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy conversion performance is a process attribute describing the ratio between the non-heat input of an energy transformation and the outputs that are used.",
-        rdfs:label "energy conversion performance"@en
+        rdfs:label "energy conversion performance"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591"
     
     SubClassOf: 
         OEO_00030019,
@@ -12152,14 +12152,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591",
 Class: OEO_00140056
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow potential is a potential of an input or output of a process, per time unit.",
+        rdfs:label "flow potential"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
 
 change: adjust definition to be based on parent class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A flow potential is a potential of an input or output of a process, per time unit.",
-        rdfs:label "flow potential"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102"
     
     SubClassOf: 
         OEO_00290000
@@ -12168,10 +12168,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
 Class: OEO_00140057
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical flow potential is a type of flow potential that identifies the physical upper limit of an input or output of a process in a spatial region of reference per unit time.",
-        rdfs:label "theoretical flow potential"@en
+        rdfs:label "theoretical flow potential"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607"
     
     SubClassOf: 
         OEO_00140056
@@ -12180,10 +12180,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140058
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A technological flow potential is a type of a flow potential derived from a theoretical flow potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
-        rdfs:label "technological flow potential"@en
+        rdfs:label "technological flow potential"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607"
     
     SubClassOf: 
         OEO_00140056
@@ -12192,10 +12192,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140059
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic flow potential is a type of flow potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
-        rdfs:label "economic flow potential"@en
+        rdfs:label "economic flow potential"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607"
     
     SubClassOf: 
         OEO_00140056
@@ -12204,10 +12204,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140060
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A developable flow potential is a type of flow potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
-        rdfs:label "developable flow potential"@en
+        rdfs:label "developable flow potential"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607"
     
     SubClassOf: 
         OEO_00140056
@@ -12216,10 +12216,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140061
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable flow potential is a type of flow potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
-        rdfs:label "sustainable flow potential"@en
+        rdfs:label "sustainable flow potential"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607"
     
     SubClassOf: 
         OEO_00140056
@@ -12228,14 +12228,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140062
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A stock potential is a potential of the stock of a source or sink.",
+        rdfs:label "stock potential"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607
 
 change: adjust definition to be based on parent class
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A stock potential is a potential of the stock of a source or sink.",
-        rdfs:label "stock potential"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102"
     
     SubClassOf: 
         OEO_00290000
@@ -12244,10 +12244,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102",
 Class: OEO_00140063
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A theoretical stock potential is a type of stock potential that identifies the physical upper limit of a stock of a source or sink in a spatial region of reference.",
-        rdfs:label "theoretical stock potential"@en
+        rdfs:label "theoretical stock potential"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607"
     
     SubClassOf: 
         OEO_00140062
@@ -12256,10 +12256,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140064
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A technological stock potential is a type of a stock potential derived from a theoretical stock potential, taking account of the annual efficiency of the respective conversion technology and the additional restrictions regarding the area that is realistically available for energy generation.",
-        rdfs:label "technological stock potential"@en
+        rdfs:label "technological stock potential"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607"
     
     SubClassOf: 
         OEO_00140062
@@ -12268,10 +12268,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140065
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An economic stock potential is a type of stock potential that identifies the proportion of the technological potential that can be utilised economically (based on economic boundary conditions).",
-        rdfs:label "economic stock potential"@en
+        rdfs:label "economic stock potential"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607"
     
     SubClassOf: 
         OEO_00140062
@@ -12280,10 +12280,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140066
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A developable stock potential is a type of stock potential that describes the fraction of the economic potential that can be developed under realistic conditions (regulations, environmental and social restrictions).",
-        rdfs:label "developable stock potential"@en
+        rdfs:label "developable stock potential"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607"
     
     SubClassOf: 
         OEO_00140062
@@ -12292,10 +12292,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140067
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sustainable stock potential is a type of stock potential that takes into account all aspects of sustainability, which usually requires careful consideration and evaluation of different ecological and socio-economic aspects. The differentiation of the sustainable potential is blurred, since ecological aspects may already have been considered for the technological or economic potential, depending on the author.",
-        rdfs:label "sustainable stock potential"@en
+        rdfs:label "sustainable stock potential"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607"
     
     SubClassOf: 
         OEO_00140062
@@ -12304,6 +12304,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/607",
 Class: OEO_00140075
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
+        rdfs:label "primary energy carrier disposition"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
 
@@ -12312,10 +12315,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 rework module structure
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "coals, cruide oil, natural gas, wood or moving air (wind) have the disposition of being primary energy carriers",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Primary energy carrier disposition is an energy carrier disposition of material entities that are extracted directly from natural resources or that are natural energy flows.",
-        rdfs:label "primary energy carrier disposition"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000151
@@ -12324,6 +12324,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140076
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
+        rdfs:label "secondary energy carrier disposition"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
 
@@ -12332,10 +12335,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000112> "blast furnace gas, coke oven gas, cokes, motor gasoline or electricity have the disposition to be a secondary energy carrier",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Secondary energy carrier disposition is an energy carrier disposition of material entities that are manufactured from primary energy carriers or from a different form of secondary energy carriers.",
-        rdfs:label "secondary energy carrier disposition"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000151
@@ -12344,11 +12344,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140077
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
         <http://purl.obolibrary.org/obo/IAO_0000112> "district heat or electricity have the disposition of being a final energy carrier",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Final energy carrier disposition is an energy carrier disposition of material entities that are delivered to energy consumers for their use.",
-        rdfs:label "final energy carrier disposition"@en
+        rdfs:label "final energy carrier disposition"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633"
     
     SubClassOf: 
         OEO_00000151
@@ -12357,11 +12357,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140078
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary energy carrier is an energy carrier that has the disposition primary energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Primärenergieträger"@de,
-        rdfs:label "primary energy carrier"@en
+        rdfs:label "primary energy carrier"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000040>
@@ -12374,6 +12374,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140079
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the secondary energy carrier disposition.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Sekundärenergieträger"@de,
+        rdfs:label "secondary energy carrier"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633
 fix error in definition
@@ -12385,10 +12388,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1522
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1531
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary energy carrier is an energy carrier that has the secondary energy carrier disposition.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Sekundärenergieträger"@de,
-        rdfs:label "secondary energy carrier"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000040>
@@ -12401,11 +12401,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140080
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A final energy carrier is an energy carrier that has the disposition final energy carrier disposition.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Endenergieträger"@de,
-        rdfs:label "final energy carrier"@en
+        rdfs:label "final energy carrier"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/575
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000040>
@@ -12418,6 +12418,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/633",
 Class: OEO_00140081
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission rate is a process attribute that describes the output of an emission process.",
+        rdfs:label "emission rate"@en,
         OEO_00020426 "class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
@@ -12434,9 +12436,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission rate is a process attribute that describes the output of an emission process.",
-        rdfs:label "emission rate"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846"
     
     SubClassOf: 
         OEO_00030019,
@@ -12447,14 +12447,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
 Class: OEO_00140082
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission rate is an emission rate that describes the output of a greenhouse gas emission process.",
+        rdfs:label "greenhouse gas emission rate"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
 
 restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission rate is an emission rate that describes the output of a greenhouse gas emission process.",
-        rdfs:label "greenhouse gas emission rate"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846"
     
     SubClassOf: 
         OEO_00140081,
@@ -12464,17 +12464,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
 Class: OEO_00140083
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide equivalent quantity is a greenhouse gas emission value that quantifies the combined effect of all emitted greenhouse gases by giving an equivalent amount of CO2 which would have the same effect on the climate.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 equivalent quantity"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2-Äquivalent"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Kohlendioxid-Äquivalent"@de,
+        rdfs:label "carbon dioxide equivalent quantity value"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/420
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/651
 
 restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A carbon dioxide equivalent quantity is a greenhouse gas emission value that quantifies the combined effect of all emitted greenhouse gases by giving an equivalent amount of CO2 which would have the same effect on the climate.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2 equivalent quantity"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2-Äquivalent"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Kohlendioxid-Äquivalent"@de,
-        rdfs:label "carbon dioxide equivalent quantity value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846"
     
     SubClassOf: 
         OEO_00010079
@@ -12483,11 +12483,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846",
 Class: OEO_00140091
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Plutonium is a portion of matter with the chemical formula Pu. It has a solid normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Plutonium"@de,
-        rdfs:label "plutonium"@en
+        rdfs:label "plutonium"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708"
     
     SubClassOf: 
         OEO_00000331,
@@ -12499,11 +12499,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
 Class: OEO_00140092
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Thorium is a portion of matter with the chemical formula Th. It has a solid normal state of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Thorium"@de,
-        rdfs:label "thorium"@en
+        rdfs:label "thorium"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/694
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708"
     
     SubClassOf: 
         OEO_00000331,
@@ -12515,6 +12515,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/708",
 Class: OEO_00140101
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat transfer is an energy transfer of thermal energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Wärmeübertragung"@de,
+        rdfs:label "heat transfer"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/730
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/733
 
@@ -12527,10 +12530,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041
 
 Shorten definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Heat transfer is an energy transfer of thermal energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Wärmeübertragung"@de,
-        rdfs:label "heat transfer"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299"
     
     SubClassOf: 
         OEO_00020103,
@@ -12547,6 +12547,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
 Class: OEO_00140102
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an energy converting component that is used for a heat transfer process.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Wärmetauscher"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Wärmeübertrager"@de,
+        rdfs:label "heat exchanger"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/713
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/734
 
@@ -12559,14 +12563,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
 fix definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1263
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1264",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A heat exchanger is an energy converting component that is used for a heat transfer process.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Wärmetauscher"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Wärmeübertrager"@de,
-        rdfs:label "heat exchanger"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1264"
     
     SubClassOf: 
         OEO_00000011,
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140101,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
@@ -12574,17 +12575,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
-        OEO_00010235 some OEO_00000207,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140101
+        OEO_00010235 some OEO_00000207
     
     
 Class: OEO_00140104
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Natural ambient thermal energy is ambient thermal energy that has a renewable origin.",
-        rdfs:label "natural ambient thermal energy"@en
+        rdfs:label "natural ambient thermal energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
     
     SubClassOf: 
         OEO_00000056,
@@ -12594,10 +12594,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
 Class: OEO_00140105
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Artificial ambient thermal energy is ambient thermal energy that has an anthropogenic origin.",
-        rdfs:label "artificial ambient thermal energy"@en
+        rdfs:label "artificial ambient thermal energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742"
     
     SubClassOf: 
         OEO_00000056,
@@ -12608,29 +12608,29 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742",
 Class: OEO_00140106
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity.",
+        rdfs:label "ambient thermal energy transfer"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/728
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/742
 
 change 'has physical input / output' axioms to 'has energy input / output':
 https://github.com/OpenEnergyPlatform/ontology/issues/994
-https://github.com/OpenEnergyPlatform/ontology/pull/1041",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ambient thermal energy transfer is a heat transfer from the ambient air to a transportable material entity.",
-        rdfs:label "ambient thermal energy transfer"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1041"
     
     SubClassOf: 
         OEO_00140101,
-        OEO_00010234 some OEO_00000056,
-        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>
+        <http://purl.obolibrary.org/obo/RO_0000057> some <http://purl.obolibrary.org/obo/BFO_0000040>,
+        OEO_00010234 some OEO_00000056
     
     
 Class: OEO_00140116
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fluid is a material entity which is a liquid, gas or plasma.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Fluid"@de,
-        rdfs:label "fluid"@en
+        rdfs:label "fluid"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/763
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000040>
@@ -12643,6 +12643,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/769",
 Class: OEO_00140126
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Planned availability is a quality that describes the amount of time a power plant is planned to be operational per year.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "geplante Verfügbarkeit"@de,
+        rdfs:label "planned availability"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779
 
@@ -12652,15 +12655,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Planned availability is a quality that describes the amount of time a power plant is planned to be operational per year.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "geplante Verfügbarkeit"@de,
-        rdfs:label "planned availability"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140127,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031,
+        OEO_00140002 some OEO_00140127
     
     
 Class: OEO_00140127
@@ -12669,10 +12669,10 @@ Class: OEO_00140127
 Class: OEO_00140128
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Block size is the declared net capacity of a power generating unit.",
-        rdfs:label "block size"@en
+        rdfs:label "block size"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
     
     SubClassOf: 
         OEO_00230002,
@@ -12682,6 +12682,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779",
 Class: OEO_00140129
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Unplanned availability is a quality that describes the amount of time a power plant is planned to be operational per year, but is not operation.",
+        rdfs:label "unplanned availability"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779
 
@@ -12691,19 +12693,22 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1310
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Unplanned availability is a quality that describes the amount of time a power plant is planned to be operational per year, but is not operation.",
-        rdfs:label "unplanned availability"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>,
-        OEO_00140002 some OEO_00140127,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000031,
+        OEO_00140002 some OEO_00140127
     
     
 Class: OEO_00140133
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy share is a process attribute that indicates the fraction of renewable energy related to the total energy of an energy generation or consumption process.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "RE share"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbarer Anteil"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "renewables share"@en,
+        rdfs:label "renewable energy share"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/780
@@ -12712,12 +12717,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A renewable energy share is a process attribute that indicates the fraction of renewable energy related to the total energy of an energy generation or consumption process.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "RE share"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbarer Anteil"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "renewables share"@en,
-        rdfs:label "renewable energy share"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
     SubClassOf: 
         OEO_00030019,
@@ -12727,11 +12727,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00140134
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen fuel cell is a fuel cell that uses hydrogen.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserstoffbrennstoffzelle"@de,
-        rdfs:label "hydrogen fuel cell"@en
+        rdfs:label "hydrogen fuel cell"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
     
     SubClassOf: 
         OEO_00000016,
@@ -12741,11 +12741,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
 Class: OEO_00140135
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A natural gas turbine is a gas turbine fueled with natural gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Erdgasturbine"@de,
-        rdfs:label "natural gas turbine"@en
+        rdfs:label "natural gas turbine"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/761
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782"
     
     SubClassOf: 
         OEO_00000185,
@@ -12755,11 +12755,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/782",
 Class: OEO_00140144
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Full load hours are a quantity value that describes the utilization of a technical device. The value of the full load hours is obtained by dividing the annual amount of energy generated by the declared net capacity of the plant.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Volllaststunden"@de,
-        rdfs:label "full load hours"@en
+        rdfs:label "full load hours"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793"
     
     SubClassOf: 
         OEO_00000350,
@@ -12769,6 +12769,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/793",
 Class: OEO_00140146
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy demand is a demand for energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Energiebedarf"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Energienachfrage"@de,
+        rdfs:label "energy demand"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/794
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796
@@ -12779,11 +12783,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Energy demand is a demand for energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Energiebedarf"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Energienachfrage"@de,
-        rdfs:label "energy demand"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
     SubClassOf: 
         OEO_00140040
@@ -12792,6 +12792,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00140159
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Kohlenwasserstoff"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
+        rdfs:label "hydrocarbon"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
 
@@ -12800,11 +12804,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrocarbon is a portion of matter which is member of class of organic chemical compounds composed only of the elements carbon (C) and hydrogen (H).",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Kohlenwasserstoff"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.britannica.com/science/hydrocarbon",
-        rdfs:label "hydrocarbon"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000331,
@@ -12815,6 +12815,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00140160
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often carbon dioxide, that can be used as fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Syngas"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Synthesegas"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Syngas",
+        rdfs:label "syngas"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/786
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/805
 
@@ -12827,12 +12832,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009
 
 add axiom to secondary energy carrier disposition
 issue:https://github.com/OpenEnergyPlatform/ontology/issues/1222
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Syngas is a gas mixture consisting primarily of hydrogen, carbon monoxide, and very often carbon dioxide, that can be used as fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Syngas"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Synthesegas"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Syngas",
-        rdfs:label "syngas"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243"
     
     SubClassOf: 
         OEO_00010236,
@@ -12847,15 +12847,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1243",
 Class: OEO_00140162
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
+        rdfs:label "power plant with electro motive generator"@en,
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002214>,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power plant with electromotive generator is a power plant that has an electro motive generator.",
-        rdfs:label "power plant with electro motive generator"@en,
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002214>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
     
     EquivalentTo: 
         OEO_00000031
@@ -12868,15 +12868,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879",
 Class: OEO_00160001
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Frequency control is a process that regulates the electricity output of an artificial object to maintain the equilibrium between electricity supply and demand.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Frequenzregelung"@de,
+        rdfs:label "frequency control"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202
 
 add 'has participant axiom':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Frequency control is a process that regulates the electricity output of an artificial object to maintain the equilibrium between electricity supply and demand.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Frequenzregelung"@de,
-        rdfs:label "frequency control"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -12888,11 +12888,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
 Class: OEO_00160002
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A primary control is a frequency control that is decentralised and automated. It reacts within seconds to frequency deviations caused by electricity supply and demand imbalances.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Primärregelung"@de,
-        rdfs:label "primary control"@en
+        rdfs:label "primary control"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202"
     
     SubClassOf: 
         OEO_00160001
@@ -12901,11 +12901,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
 Class: OEO_00160003
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A secondary control is a frequency control that is centralised and automated. It refers to the control area of one transmission system operator. Secondary control succeeds primary control and operates for several minutes.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Sekundärregelung"@de,
-        rdfs:label "secondary control"@en
+        rdfs:label "secondary control"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202"
     
     SubClassOf: 
         OEO_00160001
@@ -12914,12 +12914,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
 Class: OEO_00160004
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tertiary control is a frequency control that is either automated or manual. It takes over from secondary control to equalise electricity supply and demand imbalances that last for more than 15 minutes.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Minutenreserve"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Tertiärregelung"@de,
-        rdfs:label "tertiary control"@en
+        rdfs:label "tertiary control"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1107
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202"
     
     SubClassOf: 
         OEO_00160001
@@ -12928,15 +12928,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1202",
 Class: OEO_00230000
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Speicherkapazität"@de,
+        rdfs:label "energy storage capacity"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
 
 Changed 'storage capacity' to 'energy storage capacity' 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage capacity is the quantity value stating the maximum energy an energy storage object can store.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Speicherkapazität"@de,
-        rdfs:label "energy storage capacity"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486"
     
     SubClassOf: 
         OEO_00010256,
@@ -12946,6 +12946,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
 Class: OEO_00230001
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A power rating is a maximum value stating the maximum power an energy converting component can convert.",
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
+        <http://purl.obolibrary.org/obo/IAO_0000118> "installed power",
+        rdfs:label "power rating"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
 
@@ -12962,13 +12968,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155
 
 Restructure 'power rating' and 'power capacity':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1492
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1770",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A power rating is a maximum value stating the maximum power an energy converting component can convert.",
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
-        <http://purl.obolibrary.org/obo/IAO_0000118> "installed power",
-        rdfs:label "power rating"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1770"
     
     SubClassOf: 
         OEO_00010256,
@@ -12979,6 +12979,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/779"
 Class: OEO_00230002
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Declared net capacity is a power capacity stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Nettonennleistung"@de,
+        rdfs:label "declared net capacity"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
 
@@ -12988,10 +12991,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/935
 
 Make subclass of 'power capacity':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Declared net capacity is a power capacity stating the maximum power a power generating unit or a power plant can deliver to the electrical grid. It equals the sum of the rated powers of all plant generators minus all power used internally within the plant.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Nettonennleistung"@de,
-        rdfs:label "declared net capacity"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155"
     
     SubClassOf: 
         OEO_00010257,
@@ -13003,6 +13003,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00230003
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Nameplate capacity is the power capacity stating the maximum power an artificial object, e.g. a power generating unit or a power plant, can generate, and the sum of the power ratings of all energy converting component of that power plant.",
+        rdfs:label "nameplate capacity"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/320
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/391
 extend to artificial objects:
@@ -13016,9 +13018,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/993
 
 Make subclass of 'power capacity':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Nameplate capacity is the power capacity stating the maximum power an artificial object, e.g. a power generating unit or a power plant, can generate, and the sum of the power ratings of all energy converting component of that power plant.",
-        rdfs:label "nameplate capacity"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155"
     
     SubClassOf: 
         OEO_00010257,
@@ -13028,8 +13028,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00230020
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Kinetic energy is the energy that a material entity possesses due to its motion. It is defined as the work needed to accelerate a body of a given mass from rest to a stated velocity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "kinetische Energie"@de,
         rdfs:label "kinetic energy"@en,
@@ -13040,7 +13038,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810
 Convert to skos:closeMatch
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
-        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000017>
+        skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_2000017>,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/522
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/609"@en
     
     SubClassOf: 
         OEO_00000150
@@ -13049,6 +13049,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1879"
 Class: OEO_00230021
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A photon is a material entity that is a light particle."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Photon"@de,
+        
+            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
+        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_30212",
+        rdfs:label "photon"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/661
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/663
 pull request: https://github.com/OpenEnergyPlatform/ontology/issues/674
@@ -13058,14 +13065,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
 remove origin 
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
 classify as material entity
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A photon is a material entity that is a light particle."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Photon"@de,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/636
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/810"
-        <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CHEBI_30212",
-        rdfs:label "photon"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1165"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000040>,
@@ -13079,11 +13079,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732"
 Class: OEO_00240000
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Rotational energy is the kinetic energy that a material entity possesses due to its rotational motion."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Rotationsenergie"@de,
-        rdfs:label "rotational energy"@en
+        rdfs:label "rotational energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/787
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817"
     
     SubClassOf: 
         OEO_00230020
@@ -13092,6 +13092,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/817",
 Class: OEO_00240003
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the transformation process of combining various inputs in order to create an output that is a good."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Produktion"@de,
+        rdfs:label "production"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/835
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/845
 reclassify and make equivalent
@@ -13099,25 +13102,29 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1526
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1575
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Production is the transformation process of combining various inputs in order to create an output that is a good."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Produktion"@de,
-        rdfs:label "production"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00000419
-         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
          and (<http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116)
+         and (OEO_00000533 some <http://purl.obolibrary.org/obo/BFO_0000040>)
     
     SubClassOf: 
         OEO_00000419,
-        OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>,
-        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116
+        <http://purl.obolibrary.org/obo/RO_0002234> some OEO_00010116,
+        OEO_00000532 some <http://purl.obolibrary.org/obo/BFO_0000040>
     
     
 Class: OEO_00240009
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generation (CHP) process is an energy transformation that converts energy simultaneously to electrical energy and thermal energy."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CHP"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "KWK"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Kraft-Wärme-Kopplung"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generation"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "combined heat and power generation",
+        rdfs:label "combined heat and power generation process"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
 
@@ -13127,14 +13134,7 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1041
 
 Relabel and add old label as alternative label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1455
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generation (CHP) process is an energy transformation that converts energy simultaneously to electrical energy and thermal energy."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CHP"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "KWK"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Kraft-Wärme-Kopplung"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generation"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "combined heat and power generation",
-        rdfs:label "combined heat and power generation process"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562"
     
     SubClassOf: 
         OEO_00020003,
@@ -13145,6 +13145,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562",
 Class: OEO_00240010
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generating unit is an energy transformation unit that has both the function to produce thermal energy and the function to produce electrical energy.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "KWK-Anlage"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Kraft-Wärme-Kopplungs-Anlage"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generating power unit"@en,
+        rdfs:label "combined heat and power generating unit"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
 
@@ -13154,12 +13159,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
 New function-based definition:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power generating unit is an energy transformation unit that has both the function to produce thermal energy and the function to produce electrical energy.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "KWK-Anlage"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Kraft-Wärme-Kopplungs-Anlage"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "co-generating power unit"@en,
-        rdfs:label "combined heat and power generating unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360"
     
     EquivalentTo: 
         OEO_00020102
@@ -13169,8 +13169,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
     
     SubClassOf: 
         OEO_00020102,
-        OEO_00010235 some OEO_00000139,
-        OEO_00010235 some OEO_00000207,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188,
         <http://purl.obolibrary.org/obo/BFO_0000051> some 
             (OEO_00000210 or OEO_00140102),
@@ -13178,21 +13176,23 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240009,
         <http://purl.obolibrary.org/obo/RO_0000085> some 
             (OEO_00010386
-             and OEO_00010387)
+             and OEO_00010387),
+        OEO_00010235 some OEO_00000139,
+        OEO_00010235 some OEO_00000207
     
     
 Class: OEO_00240011
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power plant (CHPP) is an energy transformation unit that consists of combined heat and power generating units, a grid component feeding electric energy into an electricity grid, and a grid component feeding thermal energy into a heating grid.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CHPP",
+        rdfs:label "combined heat and power plant"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/915
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/923
 
 change as a subclass of energy transformation unit:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A combined heat and power plant (CHPP) is an energy transformation unit that consists of combined heat and power generating units, a grid component feeding electric energy into an electricity grid, and a grid component feeding thermal energy into a heating grid.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CHPP",
-        rdfs:label "combined heat and power plant"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360"
     
     SubClassOf: 
         OEO_00020102,
@@ -13205,16 +13205,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00240012
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross electricity generation is a process attribute that refers to the total amount of electrical energy produced in an electricity generation process."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Bruttostromerzeugung"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gross electricity production"@en,
+        rdfs:label "gross electricity generation"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Gross electricity generation is a process attribute that refers to the total amount of electrical energy produced in an electricity generation process."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Bruttostromerzeugung"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "gross electricity production"@en,
-        rdfs:label "gross electricity generation"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
     SubClassOf: 
         OEO_00030019,
@@ -13224,17 +13224,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897",
 Class: OEO_00240013
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Net electricity generation is a process attribute that equals to gross electricity generation minus the consumption of power stations' auxiliary services."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Nettostromerzeugung"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "net electricity production"@en,
+        rdfs:label "net electricity generation"@en,
         OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Net electricity generation is a process attribute that equals to gross electricity generation minus the consumption of power stations' auxiliary services."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Nettostromerzeugung"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "net electricity production"@en,
-        rdfs:label "net electricity generation"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065"
     
     SubClassOf: 
         OEO_00030019,
@@ -13244,6 +13244,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
 Class: OEO_00240014
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity generation",
+        rdfs:label "electricity generation process"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
 
@@ -13257,10 +13260,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1562
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity generation process is an energy transformation that has electrical energy as physical output."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "electricity generation",
-        rdfs:label "electricity generation process"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00020003
@@ -13276,11 +13276,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240015
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Liquid air production is a production that produces liquid air by cooling and compressing (gaseous) air."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Luftverflüssigung"@de,
-        rdfs:label "liquid air production"@en
+        rdfs:label "liquid air production"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/937
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945"
     
     SubClassOf: 
         OEO_00240003,
@@ -13291,6 +13291,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/945",
 Class: OEO_00240016
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a utilisation value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CF"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Nettojahresnutzungsgrad"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Nettokapazitätsfaktor"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor"@en,
+        rdfs:label "net capacity factor"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/890
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/946
 
@@ -13304,14 +13311,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435
 
 add alt label:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1995",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A net capacity factor is a utilisation value that is calculated by dividing the net electricity generation over a given time step by the declared net capacity times the length of this time step."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "A net capacity factor is typically calculated for a year but other time steps (e.g. month or day) are possible."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CF"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Nettojahresnutzungsgrad"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Nettokapazitätsfaktor"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "capacity factor"@en,
-        rdfs:label "net capacity factor"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1995"
     
     SubClassOf: 
         OEO_00320072
@@ -13320,12 +13320,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1995",
 Class: OEO_00240018
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
-        OEO_00110012 "GrossNationalElectricityConsumption = GrossElectricityGeneration + ElectricityImports - ElectricityExports",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gross national electricity consumption value is an energy consumption value measuring the consumption of electrical energy in a spatial region (e.g. a country), including gross electricity generation plus electricity imports, minus electricity exports. It is part of the gross inland energy consumption."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "gross national electricity consumption",
-        rdfs:label "gross national electricity consumption value"@en
+        rdfs:label "gross national electricity consumption value"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
+        OEO_00110012 "GrossNationalElectricityConsumption = GrossElectricityGeneration + ElectricityImports - ElectricityExports"
     
     EquivalentTo: 
         OEO_00240019
@@ -13338,6 +13338,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997"@en,
 Class: OEO_00240019
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Energieverbrauch"@de,
+        rdfs:label "energy consumption value"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/916
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/997
 
@@ -13350,10 +13353,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 Add axiom 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1832
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy consumption value is an energy amount value that measures the energy consumption over a time span."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Energieverbrauch"@de,
-        rdfs:label "energy consumption value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841"@en
     
     SubClassOf: 
         OEO_00050019,
@@ -13364,6 +13364,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1841"@en,
 Class: OEO_00240024
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
+        rdfs:label "energy service demand"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1054
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1080
 rework module structure 
@@ -13372,10 +13375,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy service demand is a demand of an agent to use energy as a means to obtain or facilitate desired end services or states."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "An example is the transport demand for goods or persons (e.g. in person/tonne-kilometres). An other example is the demand for room heating or cooling."@en,
-        rdfs:label "energy service demand"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00140040,
@@ -13385,15 +13385,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00240026
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured material is a portion of matter that is the physical output of a manufacturing process and that has a good role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "industrial material"@en,
+        rdfs:label "manufactured material"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
 
 Split 'industrial material' into 'manufactured material' and 'manufactured commodity':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1726
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A manufactured material is a portion of matter that is the physical output of a manufacturing process and that has a good role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "industrial material"@en,
-        rdfs:label "manufactured material"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840"
     
     SubClassOf: 
         OEO_00000331
@@ -13402,15 +13402,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1840",
 Class: OEO_00240027
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical substance is a portion of matter of constant composition and that is neither a metal or mineral. It is composed of molecular entities of the same type or of different types that is used in or produced by a chemical reaction involving changes to atoms or molecules. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "chemische Substanz"@de,
+        rdfs:label "chemical substance"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical substance is a portion of matter of constant composition and that is neither a metal or mineral. It is composed of molecular entities of the same type or of different types that is used in or produced by a chemical reaction involving changes to atoms or molecules. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "chemische Substanz"@de,
-        rdfs:label "chemical substance"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000331,
@@ -13421,15 +13421,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240028
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Paper is a portion of matter that is made from cellulose fibres and other plant materials. It is used for paper-based products. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Papier"@de,
+        rdfs:label "paper"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Paper is a portion of matter that is made from cellulose fibres and other plant materials. It is used for paper-based products. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Papier"@de,
-        rdfs:label "paper"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000331,
@@ -13440,15 +13440,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240029
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Cement is a portion of matter that is made from limestone and clay; other elements may be present. It is used as a building material to set as a solid mass or is used as an ingredient in making mortar or concrete. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Zement"@de,
+        rdfs:label "cement"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Cement is a portion of matter that is made from limestone and clay; other elements may be present. It is used as a building material to set as a solid mass or is used as an ingredient in making mortar or concrete. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Zement"@de,
-        rdfs:label "cement"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000331,
@@ -13459,15 +13459,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240030
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral is a portion of matter that is normally crystalline formed."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Mineral"@de,
+        rdfs:label "mineral"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A mineral is a portion of matter that is normally crystalline formed."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Mineral"@de,
-        rdfs:label "mineral"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000331
@@ -13476,15 +13476,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240031
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-metallic mineral is a mineral that does not contain any metallic content within themselves. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000116> "Some examples for non-metallic minerals are ceramic, glass, clay or gypsum."@en,
+        rdfs:label "non-metallic mineral"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-metallic mineral is a mineral that does not contain any metallic content within themselves. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000116> "Some examples for non-metallic minerals are ceramic, glass, clay or gypsum."@en,
-        rdfs:label "non-metallic mineral"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00240030,
@@ -13494,15 +13494,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240032
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A metal is a portion of matter consisting of an atom of an element that exhibits typical metallic properties, being typically shiny, with high electrical and thermal conductivity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Metall"@de,
+        rdfs:label "metal"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A metal is a portion of matter consisting of an atom of an element that exhibits typical metallic properties, being typically shiny, with high electrical and thermal conductivity."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Metall"@de,
-        rdfs:label "metal"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00000331
@@ -13511,15 +13511,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240034
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Steel is a metal that consists mainly of iron and up to 2.14 % of carbon; other elements may be present. It has a solid normal state of matter. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Stahl"@de,
+        rdfs:label "steel"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Steel is a metal that consists mainly of iron and up to 2.14 % of carbon; other elements may be present. It has a solid normal state of matter. It has a solid normal state of matter. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Stahl"@de,
-        rdfs:label "steel"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00240032,
@@ -13530,15 +13530,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240035
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-ferrous metal is a metal that does not contain a significant amount of iron in its chemical composition. It is the physical output of an industrial process and has a commodity role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Nichteisenmetall"@de,
+        rdfs:label "non-ferrous metal"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1082
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A non-ferrous metal is a metal that does not contain a significant amount of iron in its chemical composition. It is the physical output of an industrial process and has a commodity role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Nichteisenmetall"@de,
-        rdfs:label "non-ferrous metal"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00240032,
@@ -13548,13 +13548,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00240038
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
+        rdfs:label "personal living space"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1056
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1084
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A personal living space is a space requirement that one person uses for living."@en,
-        rdfs:label "personal living space"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00020136
@@ -13563,10 +13563,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00260001
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Ramping is a process attribute that describes the change in power of an energy transformation unit or an energy converting component per time step.",
-        rdfs:label "ramping"@en
+        rdfs:label "ramping"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126"
     
     SubClassOf: 
         OEO_00030019
@@ -13575,10 +13575,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
 Class: OEO_00260002
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Start-up speed is ramping during a cold start.",
-        rdfs:label "start-up speed"@en
+        rdfs:label "start-up speed"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126"
     
     SubClassOf: 
         OEO_00260001
@@ -13588,15 +13588,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126",
 Class: OEO_00260003
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A cold start is a process in which an energy transformation unit is started-up after a period of inactivity.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Kaltstart"@de,
+        rdfs:label "cold start"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/948
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1126
 
 add 'has participant axiom':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1327
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A cold start is a process in which an energy transformation unit is started-up after a period of inactivity.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Kaltstart"@de,
-        rdfs:label "cold start"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -13607,6 +13607,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395",
 Class: OEO_00260007
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission is an emission that releases carbon dioxide."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2-Emission"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon dioxide emission"@en,
+        rdfs:label "CO2 emission"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253/
@@ -13619,11 +13623,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission is an emission that releases carbon dioxide."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "CO2-Emission"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "carbon dioxide emission"@en,
-        rdfs:label "CO2 emission"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"@en
     
     EquivalentTo: 
         OEO_00000147
@@ -13636,6 +13636,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"@en,
 Class: OEO_00260008
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission rate is a greenhouse gas emission rate that describes the output of a CO2 emission process."@en,
+        rdfs:label "CO2 emission rate"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253/
 
@@ -13645,9 +13647,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission rate is a greenhouse gas emission rate that describes the output of a CO2 emission process."@en,
-        rdfs:label "CO2 emission rate"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846"@en
     
     SubClassOf: 
         OEO_00140082,
@@ -13657,15 +13657,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846"@en,
 Class: OEO_00290000
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A potential is a maximum value that describes some upper limit in a spatial region of reference.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Potential"@de,
+        rdfs:label "potential"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1093
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1102
 
 make subclass of 'maximum value':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1092
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A potential is a maximum value that describes some upper limit in a spatial region of reference.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Potential"@de,
-        rdfs:label "potential"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155"
     
     SubClassOf: 
         OEO_00010256
@@ -13674,12 +13674,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1155",
 Class: OEO_00290001
 
     Annotations: 
-        OEO_00020426 "add slope
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1087
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A slope is a quantity value with a plane angle unit that measures the angle between the plane of a surface and the horizontal plane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Neigung"@de,
-        rdfs:label "slope"@en
+        rdfs:label "slope"@en,
+        OEO_00020426 "add slope
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1087
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112"
     
     SubClassOf: 
         OEO_00000350,
@@ -13689,11 +13689,11 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
 Class: OEO_00290002
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A surface azimuth angle is a quantity value with a plane angle unit that measures the deviation of the projection on a horizontal plane of the normal to the plane from the local meridian, with zero due south, east negative, and west positive."@en,
+        rdfs:label "surface azimuth angle"@en,
         OEO_00020426 "add azimuth surface angle
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1087
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A surface azimuth angle is a quantity value with a plane angle unit that measures the deviation of the projection on a horizontal plane of the normal to the plane from the local meridian, with zero due south, east negative, and west positive."@en,
-        rdfs:label "surface azimuth angle"@en
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112"
     
     SubClassOf: 
         OEO_00000350,
@@ -13703,11 +13703,11 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1112",
 Class: OEO_00310000
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A datacenter is an artificial object that houses computer systems and associated components."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Rechenzentrum"@de,
-        rdfs:label "data center"@en
+        rdfs:label "data center"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359"
     
     SubClassOf: 
         OEO_00000061,
@@ -13717,11 +13717,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
 Class: OEO_00310001
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sewage plant is an artificial object that removes contaminants from wastewater to produce an effluent that is suitable for discharge to the surrounding environment or an intended reuse application."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kläranlage"@de,
-        rdfs:label "sewage plant"@en
+        rdfs:label "sewage plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359"
     
     SubClassOf: 
         OEO_00000061,
@@ -13732,11 +13732,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
 Class: OEO_00310004
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Industrial waste thermal energy is waste thermal energy that is energy output of some industrial process."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "industrielle Abwärme"@de,
-        rdfs:label "industrial waste thermal energy"@en
+        rdfs:label "industrial waste thermal energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359"
     
     SubClassOf: 
         OEO_00010114,
@@ -13746,11 +13746,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
 Class: OEO_00310005
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Recovered heat is a thermal energy that is physical output of an energy transformation process and that is recovered and would otherwise be emitted in the environment as waste thermal energy."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Abwärme"@de,
-        rdfs:label "recovered heat"@en
+        rdfs:label "recovered heat"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359"
     
     SubClassOf: 
         OEO_00000207
@@ -13759,11 +13759,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
 Class: OEO_00310006
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Aerothermal energy is a natural ambient thermal energy that is stored in the air of a natural environment."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "aerothermische Energie"@de,
-        rdfs:label "aerothermal energy"@en
+        rdfs:label "aerothermal energy"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359"
     
     SubClassOf: 
         OEO_00140104
@@ -13772,10 +13772,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359",
 Class: OEO_00310008
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat generating unit is an energy transformation unit that has the function to produce thermal energy.",
-        rdfs:label "heat generating unit"@en
+        rdfs:label "heat generating unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360"
     
     EquivalentTo: 
         OEO_00020102
@@ -13783,19 +13783,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
     
     SubClassOf: 
         OEO_00020102,
-        OEO_00010235 some OEO_00000207,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010248
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010248,
+        OEO_00010235 some OEO_00000207
     
     
 Class: OEO_00310009
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rotary heat exchanger is a heat exchanger that uses a wheel for a heat transfer process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Rotationswärmetauscher"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Rotationswärmeübertrager"@de,
-        rdfs:label "rotary heat exchanger"@en
+        rdfs:label "rotary heat exchanger"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432"
     
     SubClassOf: 
         OEO_00140102
@@ -13804,12 +13804,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
 Class: OEO_00310010
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A plate heat exchanger is a heat exchanger that uses a plate for a heat transfer process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Plattenwärmetauscher"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Plattenwärmeübertrager"@de,
-        rdfs:label "plate heat exchanger"@en
+        rdfs:label "plate heat exchanger"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432"
     
     SubClassOf: 
         OEO_00140102
@@ -13818,10 +13818,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
 Class: OEO_00310011
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat plant is an energy transformation unit consisting of heat generating units and a grid component that feeds thermal energy into a heating grid.",
-        rdfs:label "heat plant"@en
+        rdfs:label "heat plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360"
     
     EquivalentTo: 
         OEO_00020102
@@ -13838,10 +13838,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310012
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heat transfer unit is a heat generating unit that contains a heat exchanger and not a heater.",
-        rdfs:label "heat transfer unit"@en
+        rdfs:label "heat transfer unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360"
     
     SubClassOf: 
         OEO_00310008,
@@ -13852,14 +13852,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310013
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A boiler is a heater that increases the thermal energy of fluids.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Heizkessel"@de,
+        rdfs:label "boiler"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432
 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1570
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1771",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A boiler is a heater that increases the thermal energy of fluids.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Heizkessel"@de,
-        rdfs:label "boiler"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1771"
     
     EquivalentTo: 
         OEO_00000210
@@ -13875,25 +13875,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1771",
 Class: OEO_00310014
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combustion-based heater is a heater that increases the thermal energy using combustion.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Heizkessel"@de,
-        rdfs:label "combustion-based heater"@en
+        rdfs:label "combustion-based heater"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360"
     
     SubClassOf: 
         OEO_00000210,
-        OEO_00010234 some OEO_00000007,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010249
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010249,
+        OEO_00010234 some OEO_00000007
     
     
 Class: OEO_00310015
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electrical heater is a heater that increases the thermal energy using electric energy.",
-        rdfs:label "electrical heater"@en
+        rdfs:label "electrical heater"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360"
     
     SubClassOf: 
         OEO_00000210,
@@ -13903,24 +13903,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310017
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal heat unit is a heat transfer unit that uses geothermal energy as source.",
-        rdfs:label "geothermal heat unit"@en
+        rdfs:label "geothermal heat unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360"
     
     SubClassOf: 
         OEO_00310012,
-        OEO_00010234 some OEO_00000191,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020059
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020059,
+        OEO_00010234 some OEO_00000191
     
     
 Class: OEO_00310018
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A geothermal heat plant is a heat plant that has geothermal heat units as parts.",
-        rdfs:label "geothermal heat plant"@en
+        rdfs:label "geothermal heat plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360"
     
     SubClassOf: 
         OEO_00310011,
@@ -13931,11 +13931,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310021
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tube collector is a solar thermal collector that consists of tubes.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Röhrenkollektor"@de,
-        rdfs:label "tube collector"@en
+        rdfs:label "tube collector"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432"
     
     SubClassOf: 
         OEO_00000387
@@ -13944,11 +13944,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
 Class: OEO_00310022
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A flat-plate collector is a solar thermal collector that consists of flat-plates.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Flachkollektor"@de,
-        rdfs:label "flat-plate collector"@en
+        rdfs:label "flat-plate collector"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432"
     
     SubClassOf: 
         OEO_00000387
@@ -13957,48 +13957,48 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1432",
 Class: OEO_00310025
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A combined cycle electricity generation process is a fuel-powered electricity generation process in which a gas turbine process is followed by an steam-electric process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gas-und-Dampf-Prozess"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "GuD-Prozess"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "combined cycle electricity generation"@en,
-        rdfs:label "combined cycle electricity generation process"@en
+        rdfs:label "combined cycle electricity generation process"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362"
     
     SubClassOf: 
         OEO_00050001,
-        OEO_00010234 some OEO_00000139,
-        OEO_00010234 some OEO_00240000,
         <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00050020,
-        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00310027
+        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00310027,
+        OEO_00010234 some OEO_00000139,
+        OEO_00010234 some OEO_00240000
     
     
 Class: OEO_00310027
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas turbine process is an energy transformation that converts chemical energy into rotational energy using a continous internal combustion process. A gas turbine is participating in a gas turbine process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gasturbinenprozess"@de,
-        rdfs:label "gas turbine process"@en
+        rdfs:label "gas turbine process"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362"
     
     SubClassOf: 
         OEO_00020003,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140038,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000185,
         OEO_00000532 some OEO_00000099,
         OEO_00010234 some OEO_00000007,
-        OEO_00010235 some OEO_00240000,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140038,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000185
+        OEO_00010235 some OEO_00240000
     
     
 Class: OEO_00310028
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1256
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A steam power unit is a power generating unit that only has a steam turbine as turbine.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Dampfkraftwerksblock"@de,
-        rdfs:label "steam power unit"@en
+        rdfs:label "steam power unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1256
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362"
     
     SubClassOf: 
         OEO_00000334,
@@ -14012,27 +14012,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1362",
 Class: OEO_00310032
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A thermo-chemical heat storage object (TCS) is a thermal energy storage object that stores thermal energy through reversible exotherm/endotherm chemical reaction with thermo-chemical materials (TCM).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "TCS",
-        rdfs:label "thermo-chemical heat storage object"@en
+        rdfs:label "thermo-chemical heat storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         OEO_00000159,
-        OEO_00010234 some OEO_00000207,
-        OEO_00010235 some OEO_00000207,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140033,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000039
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000039,
+        OEO_00010234 some OEO_00000207,
+        OEO_00010235 some OEO_00000207
     
     
 Class: OEO_00310033
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A chemical heat storage object is a thermo-chemical heat storage object that stores thermal energy by using the chemical binding energy in an endotherm reaction.",
-        rdfs:label "chemical heat storage object"@en
+        rdfs:label "chemical heat storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         OEO_00310032
@@ -14041,10 +14041,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310034
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sorption heat storage object is a thermo-chemical heat storage object that stores thermal energy by using desorption.",
-        rdfs:label "sorption heat storage object"@en
+        rdfs:label "sorption heat storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         OEO_00310032,
@@ -14054,11 +14054,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310035
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Adsorption is a process that leads to an accumulation of a substance within a phase or at an interface between two phases.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Adsorption"@de,
-        rdfs:label "adsorption"@en
+        rdfs:label "adsorption"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -14071,11 +14071,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310036
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Desorption is a process that leads to a detaching of a substance that was accumulated within a phase or at an interface between two phases (for example by adsorption).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Desorption"@de,
-        rdfs:label "desorption"@en
+        rdfs:label "desorption"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -14088,26 +14088,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310037
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sensible heat storage object is a thermal energy storage object that stores thermal energy through temperature changes in some medium.",
-        rdfs:label "sensible heat storage object"@en
+        rdfs:label "sensible heat storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         OEO_00000159,
-        OEO_00010234 some OEO_00000207,
-        OEO_00010235 some OEO_00000207,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00140101,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000039
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000039,
+        OEO_00010234 some OEO_00000207,
+        OEO_00010235 some OEO_00000207
     
     
 Class: OEO_00310038
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sensible fluid heat storage object is a sensible heat storage that uses fluids (like water, oil, …) to store thermal energy.",
-        rdfs:label "sensible fluid heat storage object"@en
+        rdfs:label "sensible fluid heat storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         OEO_00310037,
@@ -14117,10 +14117,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310039
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A sensible solid heat storage object is a sensible heat storage that uses solid materials (like bulk goods, powder, …) to store thermal energy.",
-        rdfs:label "sensible solid heat storage object"@en
+        rdfs:label "sensible solid heat storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         OEO_00310037,
@@ -14132,11 +14132,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310040
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A phase transition is a transformation of a medium from a solid, liquid, or gas state to a different state.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Phasenübergang"@de,
-        rdfs:label "phase transition"@en
+        rdfs:label "phase transition"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
@@ -14147,12 +14147,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310041
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Evaporation is a phase transition from a liquid medium to their gaseous state.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Verdunstung"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "evaporating"@en,
-        rdfs:label "evaporation"@en
+        rdfs:label "evaporation"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         OEO_00310040,
@@ -14167,11 +14167,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310042
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Melting is a phase transition from a solid medium to their liquid state.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "schmelzen"@de,
-        rdfs:label "melting"@en
+        rdfs:label "melting"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1303
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         OEO_00310040,
@@ -14186,27 +14186,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310043
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A latent heat storage object (LHS) is a thermal energy storage object that stores thermal energy through phase transitions in phase-change materials (PCM).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "LHS",
-        rdfs:label "latent heat storage object"@en
+        rdfs:label "latent heat storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         OEO_00000159,
-        OEO_00010234 some OEO_00000207,
-        OEO_00010235 some OEO_00000207,
         <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00310040,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000039
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00000039,
+        OEO_00010234 some OEO_00000207,
+        OEO_00010235 some OEO_00000207
     
     
 Class: OEO_00310044
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A latent solid-fluid heat storage object is a latent heat storage object that stores thermal energy by converting solid materials to their liquid equivalent i.e. melting the material.",
-        rdfs:label "latent solid-fluid heat storage object"@en
+        rdfs:label "latent solid-fluid heat storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         OEO_00310043,
@@ -14216,10 +14216,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310045
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A latent fluid-gaseous heat storage object is a latent heat storage object that stores thermal energy by converting liquid materials to their gaseous equivalent i.e. evaporating the material.",
-        rdfs:label "latent fluid-gaseous heat storage object"@en
+        rdfs:label "latent fluid-gaseous heat storage object"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1261
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363"
     
     SubClassOf: 
         OEO_00310043,
@@ -14229,10 +14229,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1363",
 Class: OEO_00310047
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         rdfs:comment "A solar heat plant is a heat plant that has solar heat units as parts.",
-        rdfs:label "solar heat plant"@en
+        rdfs:label "solar heat plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360"
     
     SubClassOf: 
         OEO_00310011,
@@ -14243,28 +14243,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
 Class: OEO_00310048
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar heat unit is a heat generating unit that has a solar collector.",
-        rdfs:label "solar heat unit"@en
+        rdfs:label "solar heat unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1254
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1360"
     
     SubClassOf: 
         OEO_00310008,
-        OEO_00010234 some OEO_00000384,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000387,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020047
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020047,
+        OEO_00010234 some OEO_00000384
     
     
 Class: OEO_00320000
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance value is a quantity value that indicates the performance of a transport process in terms of its mileage and amount of transported people and/or goods."@en,
+        rdfs:label "transport performance value"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance value is a quantity value that indicates the performance of a transport process in terms of its mileage and amount of transported people and/or goods."@en,
-        rdfs:label "transport performance value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en
     
     SubClassOf: 
         OEO_00000350,
@@ -14274,13 +14274,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"@en,
 Class: OEO_00320001
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance unit is a unit of measurement for the accumulated transport distance of a number of people and/or amount of goods.",
+        rdfs:label "transport performance unit"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport performance unit is a unit of measurement for the accumulated transport distance of a number of people and/or amount of goods.",
-        rdfs:label "transport performance unit"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000000>
@@ -14289,6 +14289,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00320002
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Passenger-kilometre is a transport performance unit for the accumulated transport distance of people where one passenger-kilometre equals the transport distance of 1 km for one person.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Personenkilometer"@de,
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "pkm",
+        rdfs:label "passenger-kilometre"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
 
@@ -14297,11 +14301,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Passenger-kilometre is a transport performance unit for the accumulated transport distance of people where one passenger-kilometre equals the transport distance of 1 km for one person.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Personenkilometer"@de,
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "pkm",
-        rdfs:label "passenger-kilometre"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00320001
@@ -14310,6 +14310,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00320003
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Ton-kilometre is a transport performance unit for the accumulated transport distance of goods where one ton-kilometre equals the transport distance of 1 km for one ton of goods.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Tonnenkilometer"@de,
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "tkm",
+        rdfs:label "ton-kilometre"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1272
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1289
 
@@ -14319,11 +14323,7 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Ton-kilometre is a transport performance unit for the accumulated transport distance of goods where one ton-kilometre equals the transport distance of 1 km for one ton of goods.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Tonnenkilometer"@de,
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "tkm",
-        rdfs:label "ton-kilometre"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00320001
@@ -14332,15 +14332,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00320004
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas vehicle is an internal combustion vehicle that has only a gas engine as a motor for propulsion."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Gasfahrzeug"@de,
+        rdfs:label "gas vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290
 
 Convert to equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas vehicle is an internal combustion vehicle that has only a gas engine as a motor for propulsion."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Gasfahrzeug"@de,
-        rdfs:label "gas vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en
     
     EquivalentTo: 
         OEO_00000240
@@ -14356,15 +14356,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en,
 Class: OEO_00320005
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquefied petroleum gas vehicle is a gas vehicle that uses liquefied petroleum gas as fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Autogasfahrzeug"@de,
+        rdfs:label "liquefied petroleum gas vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290
 
 Convert to equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquefied petroleum gas vehicle is a gas vehicle that uses liquefied petroleum gas as fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Autogasfahrzeug"@de,
-        rdfs:label "liquefied petroleum gas vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en
     
     EquivalentTo: 
         OEO_00320004
@@ -14377,14 +14377,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en,
 Class: OEO_00320006
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed gas vehicle is a gas vehicle that uses a compressed gas fuel."@en,
+        rdfs:label "compressed gas vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290
 
 Convert to equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed gas vehicle is a gas vehicle that uses a compressed gas fuel."@en,
-        rdfs:label "compressed gas vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en
     
     EquivalentTo: 
         OEO_00320004
@@ -14397,15 +14397,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en,
 Class: OEO_00320007
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquefied natural gas vehicle is a gas vehicle that uses liquefied natural gas as fuel."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Flüssiggasfahrzeug"@de,
+        rdfs:label "liquefied natural gas vehicle"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290
 
 Convert to equivalent class:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1311
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A liquefied natural gas vehicle is a gas vehicle that uses liquefied natural gas as fuel."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Flüssiggasfahrzeug"@de,
-        rdfs:label "liquefied natural gas vehicle"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en
     
     EquivalentTo: 
         OEO_00320004
@@ -14418,11 +14418,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1315"@en,
 Class: OEO_00320008
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas engine is an internal combustion engine that uses a gaseous combustion fuel."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gasmotor"@de,
-        rdfs:label "gas engine"@en
+        rdfs:label "gas engine"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en
     
     SubClassOf: 
         OEO_00010029,
@@ -14432,10 +14432,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
 Class: OEO_00320009
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed gas engine is a gas engine that uses a compressed gas fuel."@en,
-        rdfs:label "compressed gas engine"@en
+        rdfs:label "compressed gas engine"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en
     
     SubClassOf: 
         OEO_00320008,
@@ -14445,10 +14445,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
 Class: OEO_00320010
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed gas fuel role is a fuel role that expresses that a portion of matter can be used in a compressed gas engine."@en,
-        rdfs:label "compressed gas fuel role"@en
+        rdfs:label "compressed gas fuel role"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en
     
     SubClassOf: 
         OEO_00000001
@@ -14457,11 +14457,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
 Class: OEO_00320011
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Liquefied petroleum gas (LPG) is gas mixture of hydrocarbon gases, mainly propane and butane."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "LPG"@en,
-        rdfs:label "liquefied petroleum gas"@en
+        rdfs:label "liquefied petroleum gas"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en
     
     SubClassOf: 
         OEO_00010236,
@@ -14473,12 +14473,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
 Class: OEO_00320012
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed natural gas (CNG) is natural gas that has been compressed."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "CNG"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "komprimiertes Erdgas"@de,
-        rdfs:label "compressed natural gas"@en
+        rdfs:label "compressed natural gas"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en
     
     SubClassOf: 
         OEO_00000292,
@@ -14488,11 +14488,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
 Class: OEO_00320013
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed biomethane is biomethane that has been compressed."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "verdichtetes Biomethan"@de,
-        rdfs:label "compressed biomethane"@en
+        rdfs:label "compressed biomethane"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en
     
     SubClassOf: 
         OEO_00010215,
@@ -14502,10 +14502,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
 Class: OEO_00320014
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "Compressed synthetic methane is synthetic methane that has been compressed."@en,
-        rdfs:label "compressed synthetic methane"@en
+        rdfs:label "compressed synthetic methane"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en
     
     SubClassOf: 
         OEO_00010018,
@@ -14515,10 +14515,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
 Class: OEO_00320015
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed gas fuel is a combustion fuel that has a compressed gas fuel role."@en,
-        rdfs:label "compressed gas fuel"@en
+        rdfs:label "compressed gas fuel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1279
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en
     
     EquivalentTo: 
         OEO_00000099
@@ -14531,29 +14531,29 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1290"@en,
 Class: OEO_00320016
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network is a supply system of transport network components that enables the transport of people and/or goods."@en,
+        rdfs:label "transport network"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297
 
 make subclass of supply system:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network is a supply system of transport network components that enables the transport of people and/or goods."@en,
-        rdfs:label "transport network"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947"
     
     SubClassOf: 
         OEO_00030025,
-        OEO_00140002 some OEO_00140001,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320021
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320021,
+        OEO_00140002 some OEO_00140001
     
     
 Class: OEO_00320017
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A road network is a transport network that enables transport on roads."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Straßennetz"@de,
-        rdfs:label "road network"@en
+        rdfs:label "road network"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320016,
@@ -14563,11 +14563,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320018
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A rail network is a transport network that enables transport on rails."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Schienennetz"@de,
-        rdfs:label "rail network"@en
+        rdfs:label "rail network"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320016,
@@ -14578,11 +14578,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320019
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A waterway network is a transport network that enables transport on water."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserstraßennetz"@de,
-        rdfs:label "waterway network"@en
+        rdfs:label "waterway network"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320016,
@@ -14592,11 +14592,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320020
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An aviation network is a transport network that enables air transport."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Flugverkehrsnetz"@de,
-        rdfs:label "aviation network"@en
+        rdfs:label "aviation network"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1266
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320016,
@@ -14606,14 +14606,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320021
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network component is an artificial object that is part of a transport network."@en,
+        rdfs:label "transport network component"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A transport network component is an artificial object that is part of a transport network."@en,
-        rdfs:label "transport network component"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     EquivalentTo: 
         OEO_00000061
@@ -14626,11 +14626,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00320022
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A road is a transport network component with an artificial surface that allows transport for road vehicles."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Straße"@de,
-        rdfs:label "road"@en
+        rdfs:label "road"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320021,
@@ -14640,12 +14640,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320023
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bridge is a transport network component that spans a physical obstacle without blocking the way underneath."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Brücke"@de,
         rdfs:comment "It can hold other transport network components such as rails and roads."@en,
-        rdfs:label "bridge"@en
+        rdfs:label "bridge"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320021
@@ -14654,12 +14654,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320024
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tunnel is a transport network component that is built through a certain environment (e.g. a mountain or water) and allows to pass through that environment."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Tunnel"@de,
         rdfs:comment "It can contain other transport network components such as rails and roads."@en,
-        rdfs:label "tunnel"@en
+        rdfs:label "tunnel"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320021
@@ -14668,10 +14668,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320025
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A railway is a transport network component that can only be used by trains."@en,
-        rdfs:label "railway"@en
+        rdfs:label "railway"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320021,
@@ -14681,11 +14681,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320026
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A canal is a transport network component that is an artificially created waterway."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kanal"@de,
-        rdfs:label "canal"@en
+        rdfs:label "canal"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320021
@@ -14694,10 +14694,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320027
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A transport hub is a transport network component that allows the exchange of people and/or goods."@en,
-        rdfs:label "transport hub"@en
+        rdfs:label "transport hub"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1267
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320021
@@ -14706,11 +14706,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320028
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A train station is a transport hub for trains."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Bahnhof"@de,
-        rdfs:label "train station"@en
+        rdfs:label "train station"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320027,
@@ -14720,11 +14720,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320029
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A freight train station is a train station for the exchange of goods."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Güterbahnhof"@de,
-        rdfs:label "freight train station"@en
+        rdfs:label "freight train station"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320028,
@@ -14734,11 +14734,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320030
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger train station is a train station for the exchange of passengers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Personenbahnhof"@de,
-        rdfs:label "passenger train station"@en
+        rdfs:label "passenger train station"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320028,
@@ -14748,11 +14748,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320031
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bus station is a transport hub for busses."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Bushaltestelle"@de,
-        rdfs:label "bus station"@en
+        rdfs:label "bus station"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320027,
@@ -14762,11 +14762,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320032
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A port is a transport hub for ships."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Hafen"@de,
-        rdfs:label "port"@en
+        rdfs:label "port"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320027,
@@ -14776,10 +14776,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320033
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A freight port is a port for the exchange of goods."@en,
-        rdfs:label "freight port"@en
+        rdfs:label "freight port"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320032,
@@ -14789,11 +14789,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320034
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A passenger port is a port for the exchange of passengers."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Passagierhafen"@de,
-        rdfs:label "passenger port"@en
+        rdfs:label "passenger port"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320032,
@@ -14803,11 +14803,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320035
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An airport is a transport hub for airplanes."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Flughafen"@de,
-        rdfs:label "airport"@en
+        rdfs:label "airport"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1278
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297"
     
     SubClassOf: 
         OEO_00320027,
@@ -14817,10 +14817,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1297",
 Class: OEO_00320036
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy transfer is an energy transfer of electrical energy."@en,
-        rdfs:label "electrical energy transfer"@en
+        rdfs:label "electrical energy transfer"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299"
     
     SubClassOf: 
         OEO_00020103,
@@ -14831,10 +14831,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
 Class: OEO_00320037
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Chemical energy transfer is an energy transfer of chemical energy."@en,
-        rdfs:label "chemical energy transfer"@en
+        rdfs:label "chemical energy transfer"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299"
     
     SubClassOf: 
         OEO_00020103,
@@ -14845,12 +14845,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
 Class: OEO_00320038
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel transport is the freight transport of fuels."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstofftransport"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kraftstofftransport"@de,
-        rdfs:label "fuel transport"@en
+        rdfs:label "fuel transport"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299"
     
     SubClassOf: 
         OEO_00140005,
@@ -14860,26 +14860,26 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
 Class: OEO_00320039
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Combustion fuel transport is the fuel transport of combustion fuels."@en,
-        rdfs:label "combustion fuel transport"@en
+        rdfs:label "combustion fuel transport"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1269
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299"
     
     SubClassOf: 
         OEO_00320038,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000099,
         OEO_00010234 some OEO_00000007,
-        OEO_00010235 some OEO_00000007,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000099
+        OEO_00010235 some OEO_00000007
     
     
 Class: OEO_00320040
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1307
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1312",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle charging station is an electricity grid component that transfers electrical energy into the traction battery of a battery electric vehicle."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ladesäule"@de,
-        rdfs:label "vehicle charging station"@en
+        rdfs:label "vehicle charging station"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1307
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1312"
     
     SubClassOf: 
         OEO_00000144,
@@ -14890,6 +14890,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1312",
 Class: OEO_00320041
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle operational mode is a realizable entity that determines how a vehicle is operating."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Fahrzeugbetriebsmodus"@de,
+        rdfs:comment "Examples are 'manual', 'partially automated', 'autonomous' or 'tele-operated'."@en,
+        rdfs:label "vehicle operational mode"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1304
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1314
 
@@ -14899,11 +14903,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A vehicle operational mode is a realizable entity that determines how a vehicle is operating."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Fahrzeugbetriebsmodus"@de,
-        rdfs:comment "Examples are 'manual', 'partially automated', 'autonomous' or 'tele-operated'."@en,
-        rdfs:label "vehicle operational mode"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000017>,
@@ -14913,10 +14913,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00320042
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1300
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1316",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel supply system is an energy system covering the distribution of fuels.",
-        rdfs:label "fuel supply system"@en
+        rdfs:label "fuel supply system"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1300
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1316"
     
     SubClassOf: 
         OEO_00030024
@@ -14925,11 +14925,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1316",
 Class: OEO_00320043
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel car is a car that has only a diesel engine as motor for propulsion and thus is also a diesel vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Dieselauto"@de,
-        rdfs:label "diesel car"@en
+        rdfs:label "diesel car"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010276
@@ -14944,13 +14944,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320044
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A diesel truck is a truck that has only a diesel engine as motor for propulsion and thus is also a diesel vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Diesel-LKW"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Diesellastkraftwagen"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Diesellastwagen"@de,
-        rdfs:label "diesel truck"@en
+        rdfs:label "diesel truck"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010278
@@ -14965,11 +14965,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320045
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gasoline car is a car that has only a gasoline engine as motor for propulsion and thus is also a gasoline vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Benzinauto"@de,
-        rdfs:label "gasoline car"@en
+        rdfs:label "gasoline car"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010276
@@ -14984,11 +14984,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320046
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric car is a car that has an electric traction motor and a traction battery and thus is also a battery electric vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "batterieelektrisches Auto"@de,
-        rdfs:label "battery electric car"@en
+        rdfs:label "battery electric car"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010276
@@ -15002,11 +15002,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320047
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric car is a car that has an electric traction motor and uses electrical energy from a fuel cell and thus is also a fuel cell electric vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstoffzellenauto"@de,
-        rdfs:label "fuel cell electric car"@en
+        rdfs:label "fuel cell electric car"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010276
@@ -15020,15 +15020,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320048
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed gas car is a car that uses compressed gas in a gas engine for propulsion and thus is also a compressed gas vehicle.",
-        rdfs:label "compressed gas car"@en
+        rdfs:label "compressed gas car"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010276
-         and (OEO_00000503 some OEO_00320015)
          and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320008)
+         and (OEO_00000503 some OEO_00320015)
          and (<http://purl.obolibrary.org/obo/BFO_0000051> only 
             (OEO_00320008 or (not (OEO_00010032))))
     
@@ -15039,15 +15039,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320049
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquefied petroleum gas car is a car that uses liquefied petroleum gas in a gas engine for propulsion and thus is also a liquefied petroleum gas vehicle.",
-        rdfs:label "liquefied petroleum gas car"@en
+        rdfs:label "liquefied petroleum gas car"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010276
-         and (OEO_00000503 some OEO_00320011)
          and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320008)
+         and (OEO_00000503 some OEO_00320011)
          and (<http://purl.obolibrary.org/obo/BFO_0000051> only 
             (OEO_00320008 or (not (OEO_00010032))))
     
@@ -15058,10 +15058,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320050
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A plug-in hybrid electric car is a car that can switch between an electric traction motor and an internal combustion engine for propulsion and thus is also a plug-in hybrid electric vehicle.",
-        rdfs:label "plug-in hybrid electric car"@en
+        rdfs:label "plug-in hybrid electric car"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010276
@@ -15077,11 +15077,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320051
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A battery electric truck is a truck that has an electric traction motor and a traction battery and thus is also a battery electric vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "batterieelektrischer Lastwagen"@de,
-        rdfs:label "battery electric truck"@en
+        rdfs:label "battery electric truck"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010278
@@ -15095,11 +15095,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320052
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel cell electric truck is a truck that has an electric traction motor and uses electrical energy from a fuel cell and thus is also a fuel cell electric vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstoffzellen-LKW"@de,
-        rdfs:label "fuel cell electric truck"@en
+        rdfs:label "fuel cell electric truck"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010278
@@ -15113,15 +15113,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320053
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A compressed gas truck is a truck that uses compressed gas in a gas engine for propulsion and thus is also a compressed gas vehicle.",
-        rdfs:label "compressed gas truck"@en
+        rdfs:label "compressed gas truck"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010278
-         and (OEO_00000503 some OEO_00320015)
          and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320008)
+         and (OEO_00000503 some OEO_00320015)
          and (<http://purl.obolibrary.org/obo/BFO_0000051> only 
             (OEO_00320008 or (not (OEO_00010032))))
     
@@ -15132,15 +15132,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320054
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A liquefied natural gas truck is a truck that uses liquefied natural gas in a gas engine for propulsion and thus is also a liquefied natural gas vehicle.",
-        rdfs:label "liquefied natural gas truck"@en
+        rdfs:label "liquefied natural gas truck"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1298
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345"
     
     EquivalentTo: 
         OEO_00010278
-         and (OEO_00000503 some OEO_00010237)
          and (<http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00320008)
+         and (OEO_00000503 some OEO_00010237)
          and (<http://purl.obolibrary.org/obo/BFO_0000051> only 
             (OEO_00320008 or (not (OEO_00010032))))
     
@@ -15151,11 +15151,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1345",
 Class: OEO_00320055
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A tank is an artificial object that stores a liquid or gaseous portion of matter.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Tank"@de,
-        rdfs:label "tank"@en
+        rdfs:label "tank"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1301
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356"
     
     SubClassOf: 
         OEO_00000061,
@@ -15165,27 +15165,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
 Class: OEO_00320056
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A fuel tank is a tank that stores a combustion fuel.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstofftank"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kraftstofftank"@de,
-        rdfs:label "fuel tank"@en
+        rdfs:label "fuel tank"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1301
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356"
     
     SubClassOf: 
         OEO_00320055,
-        OEO_00140002 some OEO_00230000,
-        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010321
+        <http://purl.obolibrary.org/obo/RO_0000085> some OEO_00010321,
+        OEO_00140002 some OEO_00230000
     
     
 Class: OEO_00320057
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1301
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A volume is a quantity value indicating the size of a three-dimensional spatial region.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Volumen"@de,
-        rdfs:label "volume"@en
+        rdfs:label "volume"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1301
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356"
     
     SubClassOf: 
         OEO_00000350,
@@ -15196,11 +15196,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1356",
 Class: OEO_00320058
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1308
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A filling station is energy transformation unit that transfers fuel into the fuel tank of a vehicle.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Tankstelle"@de,
-        rdfs:label "filling station"@en
+        rdfs:label "filling station"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1308
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357"
     
     SubClassOf: 
         OEO_00020102,
@@ -15215,11 +15215,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357",
 Class: OEO_00320059
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1308
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen station is a filling station that transfers hydrogen.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserstofftankstelle"@de,
-        rdfs:label "hydrogen station"@en
+        rdfs:label "hydrogen station"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1308
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357"
     
     SubClassOf: 
         OEO_00320058,
@@ -15229,11 +15229,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357",
 Class: OEO_00320060
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1308
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Hydrogen transport is the combustion fuel transport of hydrogen.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserstofftransport"@de,
-        rdfs:label "hydrogen transport"@en
+        rdfs:label "hydrogen transport"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1308
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357"
     
     SubClassOf: 
         OEO_00320039,
@@ -15243,17 +15243,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357",
 Class: OEO_00320061
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Vehicle-kilometre is a transport performance unit for the accumulated transport distance of the used vehicles themselves where one vehicle-kilometre equals the transport distance of 1 km for one vehicle.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Fahrzeugkilometer"@de,
+        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "vkm",
+        rdfs:comment "Can be obtained from passenger-kilometre/ton-kilometre by dividing through the average number of passengers/tons per vehicle respectively.",
+        rdfs:label "vehicle-kilometre"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1375
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1388
 
 restructure modules:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Vehicle-kilometre is a transport performance unit for the accumulated transport distance of the used vehicles themselves where one vehicle-kilometre equals the transport distance of 1 km for one vehicle.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Fahrzeugkilometer"@de,
-        <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "vkm",
-        rdfs:comment "Can be obtained from passenger-kilometre/ton-kilometre by dividing through the average number of passengers/tons per vehicle respectively.",
-        rdfs:label "vehicle-kilometre"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00320001
@@ -15262,15 +15262,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00320062
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity demand is the energy demand for electricity.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Strombedarf"@de,
+        rdfs:label "electricity demand"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1366
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1389
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Electricity demand is the energy demand for electricity.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Strombedarf"@de,
-        rdfs:label "electricity demand"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00140146
@@ -15279,16 +15279,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00320063
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel demand is the energy demand for fuel.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstoffbedarf"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Kraftstoffbedarf"@de,
+        rdfs:label "fuel demand"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1366
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1389
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Fuel demand is the energy demand for fuel.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Brennstoffbedarf"@de,
-        <http://purl.obolibrary.org/obo/IAO_0000118> "Kraftstoffbedarf"@de,
-        rdfs:label "fuel demand"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00140146
@@ -15297,11 +15297,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00320064
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1368
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1394",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Charging is an electrical energy transfer where the transferred energy is stored in a battery.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "laden"@de,
-        rdfs:label "charging"@en
+        rdfs:label "charging"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1368
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1394"
     
     SubClassOf: 
         OEO_00320036,
@@ -15311,11 +15311,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1394",
 Class: OEO_00320065
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1369
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1393",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bidirectional vehicle charging station is a vehicle charging station that can also feed electrical energy from the traction battery back into the electricity grid.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "bidirektionale Ladestation für Fahrzeuge"@de,
-        rdfs:label "bidirectional vehicle charging station"@en
+        rdfs:label "bidirectional vehicle charging station"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1369
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1393"
     
     SubClassOf: 
         OEO_00320040
@@ -15324,13 +15324,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1393",
 Class: OEO_00320066
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1367
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A ton of oil equivalent is an energy unit which is equal to the amount of energy released by burning one metric ton of crude oil with a certain net calorific value. That is defined as 41.868 gigajoules or 11.63 megawatt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Tonne Rohöleinheit"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "t ÖE"@de,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "toe",
-        rdfs:label "ton of oil equivalent"@en
+        rdfs:label "ton of oil equivalent"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1367
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -15339,13 +15339,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
 Class: OEO_00320067
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1367
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A kilo ton of oil equivalent is an energy unit which is equal to 1,000 tons of oil equivalent.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kilotonne Öleinheit"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "kt ÖE"@de,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "ktoe",
-        rdfs:label "kilo ton of oil equivalent"@en
+        rdfs:label "kilo ton of oil equivalent"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1367
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -15354,14 +15354,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
 Class: OEO_00320068
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1367
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A million ton of oil equivalent is an energy unit which is equal to 1,000,000 tons of oil equivalent.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Millionnen Tonnen Öleinheit"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Mt ÖE"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "megaton of oil equivalent"@en,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "Mtoe",
-        rdfs:label "million ton of oil equivalent"@en
+        rdfs:label "million ton of oil equivalent"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1367
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -15370,13 +15370,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
 Class: OEO_00320069
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1382
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A ton of coal equivalent is an energy unit which is equal to the amount of energy released by burning one metric ton of coal with a certain net calorific value. That is defined as 0.7 tons of oil equivalent (toe) and thus equals 29.3076 gigajoules or 8.141 megawatt-hours.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Tonne Steinkohleeinheit"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "t SKE"@de,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "tce",
-        rdfs:label "ton of coal equivalent"@en
+        rdfs:label "ton of coal equivalent"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1382
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -15385,13 +15385,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
 Class: OEO_00320070
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1382
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A kilo ton of coal equivalent is an energy unit which is equal to 1,000 tons of coal equivalent.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kilotonne Steinkohleeinheit"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "kt SKE"@de,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "ktce",
-        rdfs:label "kilo ton of coal equivalent"@en
+        rdfs:label "kilo ton of coal equivalent"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1382
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -15400,14 +15400,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
 Class: OEO_00320071
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1382
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A million ton of coal equivalent is an energy unit which is equal to 1,000,000 tons of coal equivalent.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Millionnen Tonnen Steinkohleeinheit"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Mt SKE"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "megaton of coal equivalent"@en,
         <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> "Mtoe",
-        rdfs:label "million ton of coal equivalent"@en
+        rdfs:label "million ton of coal equivalent"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1382
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/UO_0000111>
@@ -15416,10 +15416,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1398",
 Class: OEO_00320072
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1377
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A utilisation value is a fraction value that describes the instantaneous share of a maximum value that is utilised.",
-        rdfs:label "utilisation value"@en
+        rdfs:label "utilisation value"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1377
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435"
     
     SubClassOf: 
         OEO_00140127
@@ -15428,13 +15428,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1435",
 Class: OEO_00320074
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic life time is the operational life time during which an artificial object is profitable to the owner.",
+        rdfs:label "economic life time"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1380
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1436
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An economic life time is the operational life time during which an artificial object is profitable to the owner.",
-        rdfs:label "economic life time"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     SubClassOf: 
         OEO_00020178
@@ -15443,10 +15443,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
 Class: OEO_00330007
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel process is an energy transformation that converts electrical energy to chemical energy by synthesising portions of matter into a synthetic fuel.",
-        rdfs:label "power-to-fuel process"@en
+        rdfs:label "power-to-fuel process"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483"
     
     SubClassOf: 
         OEO_00020003,
@@ -15459,10 +15459,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00330008
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-liquid process is a power-to-fuel process that converts electrical energy to chemical energy by synthesising portions of matter into a liquid synthetic fuel.",
-        rdfs:label "power-to-liquid process"@en
+        rdfs:label "power-to-liquid process"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483"
     
     SubClassOf: 
         OEO_00330007,
@@ -15475,10 +15475,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00330009
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-fuel system is an energy transformation unit that implements a power-to-fuel process. A water electrolyser is participating in the power-to-fuel process.",
-        rdfs:label "power-to-fuel system"@en
+        rdfs:label "power-to-fuel system"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483"
     
     SubClassOf: 
         OEO_00020102,
@@ -15489,10 +15489,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00330010
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power-to-ammonia system is a power-to-gas system that implements the power-to-ammonia process.",
-        rdfs:label "power-to-ammonia system"@en
+        rdfs:label "power-to-ammonia system"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1477
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483"
     
     SubClassOf: 
         OEO_00000335,
@@ -15502,10 +15502,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1483",
 Class: OEO_00330012
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage content is an energy amount value that measures the quantity of energy stored in an energy storage object.",
-        rdfs:label "energy storage content"@en
+        rdfs:label "energy storage content"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486"
     
     SubClassOf: 
         OEO_00050019,
@@ -15515,10 +15515,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
 Class: OEO_00330013
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486",
         <http://purl.obolibrary.org/obo/IAO_0000115> "An energy storage level is a utilisation value that measures the utilisation/usage/exploitation of energy storage capacity.",
-        rdfs:label "energy storage level"@en
+        rdfs:label "energy storage level"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1466
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1486"
     
     SubClassOf: 
         OEO_00320072,
@@ -15531,15 +15531,15 @@ Class: OEO_00340062
 Class: OEO_00340063
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor value is a fraction value that quantifies an emission factor as quotient of the emissions or removals of a gas per unit activity.",
+        rdfs:label "emission factor value"@en,
         OEO_00020426 "restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846
 
 Correction of implementing mistake concerning emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An emission factor value is a fraction value that quantifies an emission factor as quotient of the emissions or removals of a gas per unit activity.",
-        rdfs:label "emission factor value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880"
     
     SubClassOf: 
         OEO_00140127
@@ -15548,15 +15548,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
 Class: OEO_00340065
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission value is an emission value that quantifies a greenhouse gas emission rate and has a mass unit.",
+        rdfs:label "greenhouse gas emission value"@en,
         OEO_00020426 "restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846
 
 Correction of implementing mistake concerning emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission value is an emission value that quantifies a greenhouse gas emission rate and has a mass unit.",
-        rdfs:label "greenhouse gas emission value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880"
     
     SubClassOf: 
         OEO_00010079,
@@ -15566,15 +15566,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
 Class: OEO_00340066
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission value is a greenhouse gas emission value that quantifies a CO2 emission rate and has a mass unit.",
+        rdfs:label "CO2 emission value"@en,
         OEO_00020426 "restructuring emission rate and emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1846
 
 Correction of implementing mistake concerning emission value
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1759
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A CO2 emission value is a greenhouse gas emission value that quantifies a CO2 emission rate and has a mass unit.",
-        rdfs:label "CO2 emission value"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880"
     
     SubClassOf: 
         OEO_00340065,
@@ -15584,15 +15584,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1880",
 Class: OEO_00340068
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity of an entity that quantifies its spatial extend.",
+        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
+        rdfs:label "size"@en,
         OEO_00020426 "restructuring of quantity values
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1848
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1851
 Update size and add amount
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Size is a quantity of an entity that quantifies its spatial extend.",
-        <http://purl.obolibrary.org/obo/IAO_0000119> "Derived from: http://purl.allotrope.org/ontologies/result#AFR_0002109 and http://purl.obolibrary.org/obo/PATO_0000117",
-        rdfs:label "size"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905"
     
     SubClassOf: 
         OEO_00340062
@@ -15601,11 +15601,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
 Class: OEO_00340069
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An amount is a quality of an object aggregate that counts the number of entities that form the object aggregate.",
+        rdfs:label "amount"@en,
         OEO_00020426 "Update size and add amount
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1896
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An amount is a quality of an object aggregate that counts the number of entities that form the object aggregate.",
-        rdfs:label "amount"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000019>
@@ -15614,11 +15614,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1905",
 Class: OEO_00360001
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Recycling is a material transformation that regains materials and/or energy from an artificial product or waste."@en,
+        rdfs:label "recycling"@en,
         OEO_00020426 "class added: 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1376
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1638"@en,
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Recycling is a material transformation that regains materials and/or energy from an artificial product or waste."@en,
-        rdfs:label "recycling"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1638"@en
     
     SubClassOf: 
         OEO_00020264,
@@ -15632,10 +15632,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1638"@en,
 Class: OEO_00360004
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A control area is a supply grid that is under the responsibility of a transmission system operator and is a part of a supply grid."@en,
-        rdfs:label "control area"@en
+        rdfs:label "control area"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718"
     
     SubClassOf: 
         OEO_00000200
@@ -15644,10 +15644,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
 Class: OEO_00360005
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bidding zone is a two-dimensional spatial region in which market participants are able to exchange energy without capacity allocation."@en,
-        rdfs:label "bidding zone"@en
+        rdfs:label "bidding zone"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000009>
@@ -15660,10 +15660,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
 Class: OEO_00360006
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1481
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A bidding zone role is a role of a two-dimensional spatial region that is realised in market participants trading energy without capacity allocation."@en,
-        rdfs:label "bidding zone role"@en
+        rdfs:label "bidding zone role"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1481
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
@@ -15672,6 +15672,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1718",
 Class: OEO_00360007
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Flexibility is a disposition of an energy system that is able to balance energy by adjusting energy supply and energy demand."@en,
+        rdfs:label "flexibility"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717
@@ -15681,9 +15683,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Flexibility is a disposition of an energy system that is able to balance energy by adjusting energy supply and energy demand."@en,
-        rdfs:label "flexibility"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
@@ -15694,10 +15694,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00360008
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717",
         <http://purl.obolibrary.org/obo/IAO_0000115> "Energy balancing is a process that levels out energy supply and demand for system stability."@en,
-        rdfs:label "energy balancing"@en
+        rdfs:label "energy balancing"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -15706,6 +15706,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717",
 Class: OEO_00360010
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate neutrality criterion is a plan specification that intends to describe a state in which human activities result in no net effect on the climate system."@en,
+        rdfs:comment "There are several climate neutrality criteria defined, e.g. by UNFCCC, IPCC or other institutions, with more or less differing sprecifications. A climate neutrality criterion usually includes net-zero emissions but might, e.g. include non-emission effects like surface albedo."@en,
+        rdfs:label "climate neutrality criterion"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1392
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722
 
@@ -15715,10 +15718,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
 
 remove oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A climate neutrality criterion is a plan specification that intends to describe a state in which human activities result in no net effect on the climate system."@en,
-        rdfs:comment "There are several climate neutrality criteria defined, e.g. by UNFCCC, IPCC or other institutions, with more or less differing sprecifications. A climate neutrality criterion usually includes net-zero emissions but might, e.g. include non-emission effects like surface albedo."@en,
-        rdfs:label "climate neutrality criterion"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000104>
@@ -15727,15 +15727,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
 Class: OEO_00360011
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Process climate neutrality is a process attribute that conforms to some climate neutrality criteria."@en,
+        rdfs:label "process climate neutrality"@en,
         OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1392
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Process climate neutrality is a process attribute that conforms to some climate neutrality criteria."@en,
-        rdfs:label "process climate neutrality"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065"
     
     SubClassOf: 
         OEO_00030019
@@ -15744,10 +15744,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
 Class: OEO_00360013
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1392
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A climate neutral process is a process that has a process climate neutrality attribute."@en,
-        rdfs:label "climate neutral process"@en
+        rdfs:label "climate neutral process"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1392
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -15760,15 +15760,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722",
 Class: OEO_00360014
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Material climate neutrality is a disposition of a material entity that conforms to some climate neutrality criterion."@en,
+        rdfs:label "material climate neutrality"@en,
         OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1392
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1722
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2063
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Material climate neutrality is a disposition of a material entity that conforms to some climate neutrality criterion."@en,
-        rdfs:label "material climate neutrality"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>
@@ -15777,6 +15777,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2065",
 Class: OEO_00360015
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Resilience is a disposition of a system that represents the capacity of a system to absorb disturbance and reorganize so as to retain essentially the same function, structure, and feedbacks."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "B. Walker, C. S. Holling, S. R. Carpenter, and A. Kinzig, “Resilience, adaptability and transformability in social–ecological systems,” Ecol. Soc., vol. 9, no. 2, 2004, Art. no. 5",
+        rdfs:label "resilience"@en,
         OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1550
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1744
@@ -15786,10 +15789,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Resilience is a disposition of a system that represents the capacity of a system to absorb disturbance and reorganize so as to retain essentially the same function, structure, and feedbacks."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "B. Walker, C. S. Holling, S. R. Carpenter, and A. Kinzig, “Resilience, adaptability and transformability in social–ecological systems,” Ecol. Soc., vol. 9, no. 2, 2004, Art. no. 5",
-        rdfs:label "resilience"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
@@ -15799,16 +15799,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00360016
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Power system resilience is the resilience of a power system that represents the ability to limit the extent, system impact, and duration of degradation in order to sustain critical services following an extraordinary event."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "A. M. Stanković et al., \"Methods for Analysis and Quantification of Power System Resilience,\" in IEEE Transactions on Power Systems, vol. 38, no. 5, pp. 4774-4787, Sept. 2023, doi: 10.1109/TPWRS.2022.3212688.",
+        rdfs:comment "Key enablers for a resilient response include the capacity to anticipate, absorb, rapidly recover from, adapt to, and learn from such an event. Extraordinary events for the power system may be caused by natural threats, accidents, equipment failures, and deliberate physical or cyber-attacks."@en,
+        rdfs:label "power system resilience"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1550
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1744
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Power system resilience is the resilience of a power system that represents the ability to limit the extent, system impact, and duration of degradation in order to sustain critical services following an extraordinary event."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "A. M. Stanković et al., \"Methods for Analysis and Quantification of Power System Resilience,\" in IEEE Transactions on Power Systems, vol. 38, no. 5, pp. 4774-4787, Sept. 2023, doi: 10.1109/TPWRS.2022.3212688.",
-        rdfs:comment "Key enablers for a resilient response include the capacity to anticipate, absorb, rapidly recover from, adapt to, and learn from such an event. Extraordinary events for the power system may be caused by natural threats, accidents, equipment failures, and deliberate physical or cyber-attacks."@en,
-        rdfs:label "power system resilience"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         OEO_00360015,
@@ -15818,10 +15818,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00360017
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1550
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1744",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power system is an energy system covering the generation, transportation, distribution and consumption of electrical energy."@en,
-        rdfs:label "power system"@en
+        rdfs:label "power system"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1550
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1744"
     
     SubClassOf: 
         OEO_00030024
@@ -15830,15 +15830,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1744",
 Class: OEO_00360040
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A critical infrastructure role is a role of artificial objects, such as plants and systems, that are assessed to be crucial for the preservation of societal functions, health, safety and economical or social welfare."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "The definition is based on information obtained from https://eur-lex.europa.eu/legal-content/DE/TXT/?uri=CELEX:32008L0114 and https://de.wikipedia.org/w/index.php?title=Kritische_Infrastrukturen&oldid=240000353 in January 2024."@en,
+        rdfs:label "critical infrastructure role"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1792
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1809
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A critical infrastructure role is a role of artificial objects, such as plants and systems, that are assessed to be crucial for the preservation of societal functions, health, safety and economical or social welfare."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "The definition is based on information obtained from https://eur-lex.europa.eu/legal-content/DE/TXT/?uri=CELEX:32008L0114 and https://de.wikipedia.org/w/index.php?title=Kritische_Infrastrukturen&oldid=240000353 in January 2024."@en,
-        rdfs:label "critical infrastructure role"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>,
@@ -15848,15 +15848,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928",
 Class: OEO_00360041
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A critical infrastructure is a supply system of artificial objects and systems which have the critical infrastructure role."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000119> "The definition is based on information obtained from https://eur-lex.europa.eu/legal-content/DE/TXT/?uri=CELEX:32008L0114 and https://de.wikipedia.org/w/index.php?title=Kritische_Infrastrukturen&oldid=240000353 in January 2024."@en,
+        rdfs:label "critical infrastructure"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1792
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1809
 
 make subclass of supply system, edit axiom:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1833
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A critical infrastructure is a supply system of artificial objects and systems which have the critical infrastructure role."@en,
-        <http://purl.obolibrary.org/obo/IAO_0000119> "The definition is based on information obtained from https://eur-lex.europa.eu/legal-content/DE/TXT/?uri=CELEX:32008L0114 and https://de.wikipedia.org/w/index.php?title=Kritische_Infrastrukturen&oldid=240000353 in January 2024."@en,
-        rdfs:label "critical infrastructure"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947"
     
     EquivalentTo: 
         OEO_00030025
@@ -15871,12 +15871,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1947",
 Class: OEO_00390000
 
     Annotations: 
-        OEO_00020426 "added kilowatt and megawatt as units
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1890
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1900",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power unit which is equal to one thousand watts.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "kW",
-        rdfs:label "kilowatt"@en
+        rdfs:label "kilowatt"@en,
+        OEO_00020426 "added kilowatt and megawatt as units
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1890
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1900"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/UO_0000114>
@@ -15889,12 +15889,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1900",
 Class: OEO_00390001
 
     Annotations: 
-        OEO_00020426 "added kilowatt and megawatt as units
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1890
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1900",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A power unit which is equal to one million watts.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "MW",
-        rdfs:label "megawatt"@en
+        rdfs:label "megawatt"@en,
+        OEO_00020426 "added kilowatt and megawatt as units
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1890
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1900"
     
     EquivalentTo: 
         <http://purl.obolibrary.org/obo/UO_0000114>
@@ -15907,6 +15907,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1900",
 Individual: OEO_00000182
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has no definite shape and no definite volume and is not electrically conductive.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "gasförmig"@de,
+        rdfs:label "gaseous"@en,
         OEO_00020426 "move to oeo-shared:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390,
@@ -15915,10 +15918,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 Fix definition:
-https://github.com/OpenEnergyPlatform/ontology/pull/1980",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being a gas. A portion of matter is in gaseous state if and only if it has no definite shape and no definite volume and is not electrically conductive.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "gasförmig"@de,
-        rdfs:label "gaseous"@en
+https://github.com/OpenEnergyPlatform/ontology/pull/1980"
     
     Types: 
         OEO_00000395
@@ -15927,12 +15927,12 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1980",
 Individual: OEO_00000256
 
     Annotations: 
-        OEO_00020426 "restructure modules:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being liquid. A portion of matter is liquid has no definite shape but a definite volume (at a given temperature and pressure).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "flüssig"@de,
-        rdfs:label "liquid"@en
+        rdfs:label "liquid"@en,
+        OEO_00020426 "restructure modules:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
     
     Types: 
         OEO_00000395
@@ -15951,11 +15951,11 @@ Individual: OEO_00000326
 Individual: OEO_00000390
 
     Annotations: 
-        OEO_00020426 "fix wording in definition
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2019",
         <http://purl.obolibrary.org/obo/IAO_0000115> "The state of being solid. A portion of matter is in solid state if and only if it has a definite shape and volume (at a given temperature and pressure).",
         <http://purl.obolibrary.org/obo/IAO_0000118> "fest"@de,
-        rdfs:label "solid"@en
+        rdfs:label "solid"@en,
+        OEO_00020426 "fix wording in definition
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2019"
     
     Types: 
         OEO_00000395

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2393,7 +2393,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+
+Changed definition to use verb 'transfer'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2044
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2073"
     
     SubClassOf: 
         OEO_00000200,
@@ -8506,7 +8510,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1785
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928
+
+Changed class to represent a function of 'grid component link's
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2044
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2073"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8495,7 +8495,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1478"
 Class: OEO_00010410
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transfer function is a function of an artificial object that has been engineered to transfer energy over a spatial distance.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An energy transfer function is a function of a grid component link that has been engineered to transfer energy over a spatial distance."@en,
         rdfs:label "energy transfer function"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1454
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1515
@@ -8511,7 +8511,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000034>,
         <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020103,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000061
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000255
     
     
 Class: OEO_00010413


### PR DESCRIPTION
## Summary of the discussion
- The definition of `electricity grid` was inaccurate: `An electricity grid is a supply grid that distributes electrical energy / electricity.` A grid can also be used for the transmission of electricity.
- Same for the definition of `energy transfer function`: `An energy transfer function is a function of an artificial object that has been engineered to transfer energy over a spatial distance.` This definition disallows energy systems and energy grids to have the function to transfer energy.

## Type of change (CHANGELOG.md)

### Update
- Updated `electricity grid`
  - definition: `An electricity grid is a supply grid that transfers electrical energy / electricity.`
- Updated `energy transfer function`
  - definition: `An energy transfer function is a function of a grid component link that has been engineered to transfer energy over a spatial distance.`
  - changed subclass axiom: `'characteristic of' some 'artificial object'` to `'characteristic of' some 'grid component link'`

## Workflow checklist

### Automation
Closes #2044

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
