### PR TITLE
Added check to avoid old iris being used

### DIFF
--- a/tests/verify/old-iris.sparql
+++ b/tests/verify/old-iris.sparql
@@ -1,0 +1,14 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#> 
+SELECT ?old_iris
+WHERE { 
+    { ?old_iris a owl:Class . }
+    UNION 
+    { ?old_iris a owl:ObjectProperty . } 
+    UNION 
+    { ?old_iris a owl:AnnotationProperty . } 
+    UNION 
+    { ?old_iris a owl:NamedIndividual . } 
+    FILTER (!isBlank(?old_iris))
+    FILTER (strstarts(str(?old_iris), "https://openenergy-platform.org") || 
+            strstarts(str(?old_iris), "http://openenergy"))
+}


### PR DESCRIPTION
## Summary of the discussion

Discussed during [Dev meeting 100](https://etherpad.wikimedia.org/p/oeo-dev-100)

## Type of change (CHANGELOG.md)


### Meta
- Added verification of ontology iris.


## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
