### PR TITLE
Add new individuals for temporal resolution

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -756,7 +756,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2020
 change range 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2069
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2077"
-
     
     Domain: 
         <http://purl.obolibrary.org/obo/IAO_0000088> or OEO_00000162
@@ -770,7 +769,6 @@ DataProperty: OEO_00390096
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "has publication date is the relation between a report and the year it was published in.",
         rdfs:label "has publication date"@en,
-
         OEO_00020426 "add
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2020"
@@ -4460,6 +4458,39 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006"
     
     SubClassOf: 
         OEO_00410036
+    
+    
+Individual: <https://openenergyplatform.org/ontology/oeo/oeo-model/OEO_00400073>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per 15 minutes",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "viertelstündlich"@de,
+        rdfs:label "quarter-hourly"@en
+    
+    Types: 
+        OEO_00020122
+    
+    
+Individual: <https://openenergyplatform.org/ontology/oeo/oeo-model/OEO_00400074>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per minute",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "minütlich"@de,
+        rdfs:label "every minute"@en
+    
+    Types: 
+        OEO_00020122
+    
+    
+Individual: <https://openenergyplatform.org/ontology/oeo/oeo-model/OEO_00400075>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "one value per ten minutes",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "zehn minütlich"@de,
+        rdfs:label "every ten minutes"@en
+    
+    Types: 
+        OEO_00020122
     
     
 Individual: OEO_00000049


### PR DESCRIPTION
## Summary of the discussion

See #2075 
The goal of this issue was to add temporal resolutions for smaller time-frames to be used in energy time series

## Type of change (CHANGELOG.md)

### Add
- Individuals under `temporal resolution`
    - `quarter-hourly`
    - `every minute`
    - `every ten minutes`
  
## Workflow checklist

### Automation
Closes #2075

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
