### PR TITLE
Updated ro-extracted.owl with characteristic regulation properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - RO import: regulates characteristic, positively regulates characteristic, negatively regulates (#2094)
 
 ### Changed
-- causally related to (#2094)
 - air, water, biomass, biofuel, nuclear fuel (#2095)
 - 'has information content entity' renamed to 'is subject of' (#2092)
 - update license and citation (#2096)
+
 
 ### Removed
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -1143,10 +1143,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2016</oeo:OEO_
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002410">
-        <oeo:OEO_00020426>remove wrong domain and range
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2094</oeo:OEO_00020426>
-    </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002418">
         <oeo:OEO_00020426>add subset of relation below &apos;causally related to&apos;
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -262,6 +262,20 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002353>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002410>
 
+    Domain: 
+        
+            Annotations: OEO_00020426 "add domain and range
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
+        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
+    
+    Range: 
+        
+            Annotations: OEO_00020426 "add domain and range
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
+        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
+    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002418>
 


### PR DESCRIPTION
## Summary of the discussion
Issue #2053 requires the relations `positively regulates characteristic` and `negatively regulates characteristic` to be imported from the RO with their hierarchy

## Type of change (CHANGELOG.md)

### Add
- `regulates characteristic` as subproperty of `causally related to`
- `positively regulates characteristic` as subproperty of `regulates characteristic`
- `negatively regulates characteristic` as subproperty of `regulates characteristic`

## Workflow checklist

### Automation
Closes #2093 

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
