### PR TITLE
`primary energy carrier disposition` is not used in certain cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 
 
 ### Changed
+- air, water, biomass, biofuel, nuclear fuel (#2095)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1749,7 +1749,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1009
 
 remove axiom 'is used by' some 'energy storage unit'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1495
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499
+
+added axiom 'has disposition' some 'primary energy carrier disposition'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2095"
     
     SubClassOf: 
         OEO_00010236,
@@ -1932,7 +1936,11 @@ https://github.com/OpenEnergyPlatform/ontology/pull/1048
 
 delete 'renewable energy carrier disposition':
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409
+
+added axiom 'has disposition' some 'primary energy carrier disposition'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2095"
     
     EquivalentTo: 
         OEO_00000099
@@ -3714,7 +3722,11 @@ Class: OEO_00000302
         <http://purl.obolibrary.org/obo/IAO_0000118> "Kernbrennstoff"@de,
         rdfs:label "nuclear fuel"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/182
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237
+
+added axiom 'has disposition' some 'primary energy carrier disposition'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2095"
     
     EquivalentTo: 
         OEO_00000173
@@ -4638,7 +4650,11 @@ add origin
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/515
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/684
 remove origin 
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861
+
+added axiom 'has disposition' some 'primary energy carrier disposition'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2095"
     
     SubClassOf: 
         OEO_00000331,
@@ -6611,7 +6627,11 @@ Class: OEO_00010214
         <http://purl.obolibrary.org/obo/IAO_0000118> "Biomasse"@de,
         rdfs:label "biomass"@en,
         OEO_00020426 "issue:https://github.com/OpenEnergyPlatform/ontology/issues/872
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952
+
+added axiom 'has disposition' some 'primary energy carrier disposition'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1032
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2095"
     
     SubClassOf: 
         OEO_00000331,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1754,7 +1754,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1499"
     SubClassOf: 
         OEO_00010236,
         <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000446,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
         OEO_00000529 value OEO_00000182
     
     
@@ -4640,7 +4640,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/861"
     
     SubClassOf: 
         OEO_00000331,
-        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000151,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
         OEO_00000529 value OEO_00000256
     
     
@@ -6613,6 +6613,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/952"
     
     SubClassOf: 
         OEO_00000331,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
         OEO_00000530 some OEO_00030001
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -1941,6 +1941,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1409"
     SubClassOf: 
         OEO_00000099,
         <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00000097,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075,
         OEO_00000530 some OEO_00030001
     
     DisjointWith: 
@@ -3721,7 +3722,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/237"
     
     SubClassOf: 
         OEO_00000173,
-        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000300
+        <http://purl.obolibrary.org/obo/RO_0000086> some OEO_00000300,
+        <http://purl.obolibrary.org/obo/RO_0000091> some OEO_00140075
     
     
 Class: OEO_00000303


### PR DESCRIPTION
## Summary of the discussion
The classes `air`, `water`, `biomass`, `biofuel` and `nuclear fuel` should have the `primary energy carrier disposition` due to a disposition not needing to be realised in an object.

## Type of change (CHANGELOG.md)

### Update
- Added the `'has disposition' some 'primary energy carrier disposition'` to the classes `air`, `water`, `biomass`, `biofuel` and `nuclear fuel`

## Workflow checklist

### Automation
Closes #1032 

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
