### PR TITLE
Make `goal description` an `objective specification` and rename `target description`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - air, water, biomass, biofuel, nuclear fuel (#2095)
 - 'has information content entity' renamed to 'is subject of' (#2092)
 - update license and citation (#2096)
+- 'target description' renamed to 'legal target description' (#2102)
+- 'goal description' made a subclass of 'objective specification' (#2102)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -799,20 +799,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2020"
 DataProperty: owl:topDataProperty
 
     
-Class: OEO_00390104
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A multi-criteria decision analysis (MCDA) is a methodology for decision-making. It is an umbrella term to describe a collection of formal approaches, which seek to take explicit account of multiple criteria, comparing goals and outcomes by assigning weights to various criteria.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "MCDA",
-        rdfs:label "multi-criteria decision analysis"@en,
-        OEO_00020426 "Add
-Issue: https://github.com/OpenEnergyPlatform/ontology/issues/1998
-Pull: https://github.com/OpenEnergyPlatform/ontology/pull/2091"
-    
-    SubClassOf: 
-        OEO_00020166
-    
-    
 Class: <http://purl.obolibrary.org/obo/BFO_0000001>
 
     
@@ -2488,9 +2474,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/882"
 Class: OEO_00020093
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A target description is an objective specification that contains statements about a desired future state of a system that a person or organisation commits to in a legally binding way.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A legal target description is an objective specification that contains statements about a desired future state of a system that a person or organisation commits to in a legally binding way.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Zielbeschreibung"@de,
-        rdfs:label "target description"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "target description"@en,
+        rdfs:label "legal target description"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881
 
@@ -3499,14 +3486,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/724"
 Class: OEO_00140099
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A goal description is an information content entity that contains statements about a desired future state of a system that a person or organisation envisions or plans, or to which it commits.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A goal description is an objective specification that contains statements about a desired future state of a system that a person or organisation envisions or plans, or to which it commits.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Zielbeschreibung"@de,
         rdfs:label "goal description"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/729"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
+        <http://purl.obolibrary.org/obo/IAO_0000005>
     
     
 Class: OEO_00140138
@@ -3997,6 +3984,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1950"
     
     SubClassOf: 
         OEO_00000119
+    
+    
+Class: OEO_00390104
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A multi-criteria decision analysis (MCDA) is a methodology for decision-making. It is an umbrella term to describe a collection of formal approaches, which seek to take explicit account of multiple criteria, comparing goals and outcomes by assigning weights to various criteria.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "MCDA",
+        rdfs:label "multi-criteria decision analysis"@en,
+        OEO_00020426 "Add
+Issue: https://github.com/OpenEnergyPlatform/ontology/issues/1998
+Pull: https://github.com/OpenEnergyPlatform/ontology/pull/2091"
+    
+    SubClassOf: 
+        OEO_00020166
     
     
 Class: OEO_00400012

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2483,7 +2483,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/881
 
 reclassify
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1684
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1778"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1778
+
+Renamed class from 'target description' to 'legal target description'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2097
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2102"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000005>
@@ -3490,7 +3494,11 @@ Class: OEO_00140099
         <http://purl.obolibrary.org/obo/IAO_0000118> "Zielbeschreibung"@de,
         rdfs:label "goal description"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/28
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/729"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/729
+
+Changed direct parent class from 'information content entity' to 'objective specification'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2097
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2102"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000005>


### PR DESCRIPTION
## Summary of the discussion

As discussed in #2097 and the last oeo-dev meeting (nr. 103), `goal description` should be made a sibling class of `target description` and `target description` should receive a more appropriate name to help distinguish it from `goal description`.

## Type of change (CHANGELOG.md)

### Update
- Made `goal description` a subclass of `objective specification`
- Renamed `target description` to `legal target description`

## Workflow checklist

### Automation
Closes #2097 

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
