### PR TITLE
Removed domain and range from `causally related to`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - air, water, biomass, biofuel, nuclear fuel (#2095)
 - 'has information content entity' renamed to 'is subject of' (#2092)
 - update license and citation (#2096)
+- 'causally related to' no longer has domain and range (#2104)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - air, water, biomass, biofuel, nuclear fuel (#2095)
 - 'has information content entity' renamed to 'is subject of' (#2092)
 - update license and citation (#2096)
-- 'causally related to' no longer has domain and range (#2104)
+- causally related to (#2104)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -831,6 +831,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1820</oeo:OEO_
     
 
 
+    <!-- https://openenergyplatform.org/ontology/oeo/OEO_00020003 -->
+
+    <owl:Class rdf:about="https://openenergyplatform.org/ontology/oeo/OEO_00020003"/>
+    
+
+
+    <!-- https://openenergyplatform.org/ontology/oeo/OEO_00020103 -->
+
+    <owl:Class rdf:about="https://openenergyplatform.org/ontology/oeo/OEO_00020103"/>
+    
+
 
     <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002 -->
 
@@ -847,12 +858,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1820</oeo:OEO_
                 <owl:someValuesFrom rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oeo:OEO_00020426>issue: https://github.com/OpenEnergyPlatform/ontology/issues/1959
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2022
-
-readd axioms
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/2058
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2061</oeo:OEO_00020426>
         <obo:IAO_0000602>(forall (?et) (iff (EnergyTransfer ?et)  
   (exists (?ed ?ei ?en1 ?en2 ?me1 ?me2) 
     (and (EnergyDecrease ?ed) (has_part ?et ?ed) 
@@ -864,18 +869,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2061</oeo:OEO_
       (not (= ?me1 ?me2)) (not (= ?en1 ?en2))
       (has_participant ?ed ?me1) (inheres_in ?en1 ?me1) 
       (has_participant ?ei ?me2) (inheres_in ?en2 ?me2) ))))</obo:IAO_0000602>
+        <oeo:OEO_00020426>issue: https://github.com/OpenEnergyPlatform/ontology/issues/1959
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2022
+
+readd axioms
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2058
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2061</oeo:OEO_00020426>
     </owl:Class>
-
-    <!-- https://openenergyplatform.org/ontology/oeo/OEO_00020003 -->
-
-    <owl:Class rdf:about="https://openenergyplatform.org/ontology/oeo/OEO_00020003"/>
-    
-
-
-    <!-- https://openenergyplatform.org/ontology/oeo/OEO_00020103 -->
-
-    <owl:Class rdf:about="https://openenergyplatform.org/ontology/oeo/OEO_00020103"/>
-
     
 
 
@@ -916,16 +916,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2061</oeo:OEO_
                         <owl:unionOf rdf:parseType="Collection">
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                                <owl:someValuesFrom rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
-                            </owl:Restriction>
-                            <owl:Restriction>
-                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                                <owl:someValuesFrom rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
                                 <owl:someValuesFrom rdf:resource="https://openenergyplatform.org/ontology/oeo/OEO_00020003"/>
                             </owl:Restriction>
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
                                 <owl:someValuesFrom rdf:resource="https://openenergyplatform.org/ontology/oeo/OEO_00020103"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                                <owl:someValuesFrom rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
                             </owl:Restriction>
                         </owl:unionOf>
                     </owl:Class>
@@ -1132,6 +1131,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2016</oeo:OEO_
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002410">
+        <oeo:OEO_00020426>Removed class expression (process or &apos;material entity&apos;) both as domain and as range
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2103
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2104</oeo:OEO_00020426>
+    </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002418">
         <oeo:OEO_00020426>add subset of relation below &apos;causally related to&apos;
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -262,20 +262,6 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002353>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002410>
 
-    Domain: 
-        
-            Annotations: OEO_00020426 "add domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
-        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    Range: 
-        
-            Annotations: OEO_00020426 "add domain and range
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136"
-        <http://purl.obolibrary.org/obo/BFO_0000015> or <http://purl.obolibrary.org/obo/BFO_0000040>
-    
     
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002418>
 


### PR DESCRIPTION
## Summary of the discussion

As discussed in #2103, the domain and range of the RO-imported `causally related to` property should be removed.

## Type of change (CHANGELOG.md)

### Update
- Removed the domain (`process or 'material entity'`) and range (`process or 'material entity'`) from `causally related to`

## Workflow checklist

### Automation
Closes #2103

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
