### PR TITLE
Added missing characteristics of `causally upstream of or within` and `causally downstream of or within`

### DIFF
--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -384,6 +384,29 @@ pull request https://github.com/OpenEnergyPlatform/ontology/pull/1086</oeo:OEO_0
     
 
 
+    <!-- http://purl.obolibrary.org/obo/RO_0002418 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002418">
+        <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002427"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <oeo:OEO_00020426>add subset of relation below &apos;causally related to&apos;
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136</oeo:OEO_00020426>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002427 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002427">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <oeo:OEO_00020426>add subset of relation below &apos;causally related to&apos;
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
+pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136</oeo:OEO_00020426>
+    </owl:ObjectProperty>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/RO_0002501 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002501">
@@ -1147,16 +1170,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2016</oeo:OEO_
         <oeo:OEO_00020426>Removed class expression (process or &apos;material entity&apos;) both as domain and as range
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2103
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2104</oeo:OEO_00020426>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002418">
-        <oeo:OEO_00020426>add subset of relation below &apos;causally related to&apos;
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136</oeo:OEO_00020426>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002427">
-        <oeo:OEO_00020426>add subset of relation below &apos;causally related to&apos;
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1079
-pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136</oeo:OEO_00020426>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0019001">
         <oeo:OEO_00020426>import from RO


### PR DESCRIPTION
## Summary of the discussion

As discussed in #2106, some characteristics of some RO properties weren't correctly imported:
- `causally upstream of or within` should be defined as the inverse of `causally downstream of or within`
- Both should be flagged as "transitive"

## Type of change (CHANGELOG.md)

### Update
- `causally upstream of or within` 
    - flagged as transitive
    - defined as the inverse of `causally downstream of or within`
- `causally downstream of or within`
    - flagged as transitive 

## Workflow checklist

### Automation
Closes #2106

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
