### PR TITLE
Removed direct usages of `causally related to` property

### DIFF
--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -92,9 +92,6 @@ Datatype: xsd:integer
 Datatype: xsd:string
 
     
-ObjectProperty: <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
-
-    
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000050>
 
     
@@ -185,6 +182,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0003000>
 ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
 
     
+ObjectProperty: <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
+
+    
 ObjectProperty: OEO_00000500
 
     
@@ -263,7 +263,7 @@ ObjectProperty: OEO_00010231
 ObjectProperty: OEO_00010234
 
     Domain: 
-        OEO_00000061 or <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
     
     
 ObjectProperty: OEO_00010235
@@ -302,17 +302,17 @@ ObjectProperty: OEO_00020190
 ObjectProperty: OEO_00020432
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and an energy carrier that is covered by the study the scenario bundle is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'energy carrier'. The original relation 'covers energy carrier' relates 'study' (process) to 'energy carrier'. 
+The shortcut relation should be used to represents these statements:
+('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers energy carrier' some 'energy carrier')",
+        rdfs:label "covers energy carrier (shortcut)"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
         OEO_00020434 "SELECT ?scenariobundle ?energycarrier WHERE {
 ?scenariobundle IAO:0000136 _:1.
 _:1 OEO:00000523 ?energycarrier.
-}",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and an energy carrier that is covered by the study the scenario bundle is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
-        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'energy carrier'. The original relation 'covers energy carrier' relates 'study' (process) to 'energy carrier'. 
-The shortcut relation should be used to represents these statements:
-('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers energy carrier' some 'energy carrier')",
-        rdfs:label "covers energy carrier (shortcut)"@en
+}"
     
     SubPropertyOf: 
         owl:topObjectProperty
@@ -327,20 +327,20 @@ The shortcut relation should be used to represents these statements:
 ObjectProperty: OEO_00020436
 
     Annotations: 
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
-        OEO_00020434 "select ?scenariofactsheet ?dataset where {
-?scenariofactsheet IAO:0000136 _:1.
-_:2 OEO:00020226 _:1.
-_:2 OEO_00140094 ?dataset.
-}",
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario factsheet and a dataset, where the dataset is an output of the scenario projection process the scenario factsheet is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
         <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio factsheet' to 'data set'. The original relation 'has information output' relates 'scenario projection' (process) to 'data set'. 
 The shortcut relation should be used to represents these statements:
 ('scenario factsheet' 'is about' some scenario) and
 ('scenario projection' 'is based on' some scenario) and
 ('scenario projection' 'has information output' some dataset)",
-        rdfs:label "has information output (shortcut)"@en
+        rdfs:label "has information output (shortcut)"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
+        OEO_00020434 "select ?scenariofactsheet ?dataset where {
+?scenariofactsheet IAO:0000136 _:1.
+_:2 OEO:00020226 _:1.
+_:2 OEO_00140094 ?dataset.
+}"
     
     SubPropertyOf: 
         owl:topObjectProperty
@@ -355,6 +355,12 @@ The shortcut relation should be used to represents these statements:
 ObjectProperty: OEO_00020437
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio factsheet' to 'data set'. The original relation 'has information input' relates 'scenario projection' (process) to 'data set'. 
+The shortcut relation should be used to represents these statements:
+('scenario factsheet' 'is about' some scenario) and
+('scenario projection' 'is based on' some scenario) and
+('scenario projection' 'has information input' some dataset)",
+        rdfs:label "has information input (shortcut)"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
         OEO_00020434 "select ?scenariofactsheet ?dataset where {
@@ -362,12 +368,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
 _:2 OEO:00020226 _:1.
 _:2 OEO_00140093 ?dataset.
 }",
-        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio factsheet' to 'data set'. The original relation 'has information input' relates 'scenario projection' (process) to 'data set'. 
-The shortcut relation should be used to represents these statements:
-('scenario factsheet' 'is about' some scenario) and
-('scenario projection' 'is based on' some scenario) and
-('scenario projection' 'has information input' some dataset)",
-        rdfs:label "has information input (shortcut)"@en,
         <https://www.commoncoreontologies.org/ont00001754> "A relation between a scenario factsheet and a dataset, where the dataset is an input to the scenario projection process the scenario factsheet is about. It is a shortcut relation, see elucidation and associated sparql axiom."
     
     Domain: 
@@ -380,17 +380,17 @@ The shortcut relation should be used to represents these statements:
 ObjectProperty: OEO_00020438
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and a technology that is covered by the study the scenario bundle is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'technology'. The original relation 'covers technology' relates 'study' (process) to 'technology'. 
+The shortcut relation should be used to represents these statements:
+('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers technology' some 'technology')",
+        rdfs:label "covers technology (shortcut)"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
         OEO_00020434 "SELECT ?scenariobundle ?technology WHERE {
 ?scenariobundle IAO:0000136 _:1.
 _:1 OEO:00390101 ?technology.
-}",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and a technology that is covered by the study the scenario bundle is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
-        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'technology'. The original relation 'covers technology' relates 'study' (process) to 'technology'. 
-The shortcut relation should be used to represents these statements:
-('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers technology' some 'technology')",
-        rdfs:label "covers technology (shortcut)"@en
+}"
     
     SubPropertyOf: 
         owl:topObjectProperty
@@ -405,17 +405,17 @@ The shortcut relation should be used to represents these statements:
 ObjectProperty: OEO_00020439
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and a sector that is covered by the study the scenario bundle is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'sector'. The original relation 'covers sector' relates 'study' (process) to 'sector'. 
+The shortcut relation should be used to represents these statements:
+('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers sector' some 'sector')",
+        rdfs:label "covers sector (shortcut)"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023",
         OEO_00020434 "SELECT ?scenariobundle ?sector WHERE {
 ?scenariobundle IAO:0000136 _:1.
 _:1 OEO:00000505 ?sector.
-}",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and a sector that is covered by the study the scenario bundle is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
-        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenatio bundle' to 'sector'. The original relation 'covers sector' relates 'study' (process) to 'sector'. 
-The shortcut relation should be used to represents these statements:
-('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers sector' some 'sector')",
-        rdfs:label "covers sector (shortcut)"@en
+}"
     
     SubPropertyOf: 
         owl:topObjectProperty
@@ -463,11 +463,11 @@ ObjectProperty: OEO_00240025
 ObjectProperty: OEO_00390079
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "based on sector division is a relation between a scenario bundle and a sector division it is based on.",
+        rdfs:label "based on sector division"@en,
         OEO_00020426 "add
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2020",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "based on sector division is a relation between a scenario bundle and a sector division it is based on.",
-        rdfs:label "based on sector division"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2020"
     
     Domain: 
         OEO_00020227
@@ -532,9 +532,6 @@ Class: <http://purl.obolibrary.org/obo/IAO_0000310>
     
     
 Class: <http://purl.obolibrary.org/obo/UO_0000000>
-
-    
-Class: OEO_00330023
 
     
 Class: OEO_00000001
@@ -677,9 +674,9 @@ Class: OEO_00010116
 Class: OEO_00010117
 
     SubClassOf: 
-        OEO_00020180 some OEO_00040003,
         <http://purl.obolibrary.org/obo/RO_0000052> some 
-            (OEO_00000139 or <http://purl.obolibrary.org/obo/BFO_0000004>)
+            (<http://purl.obolibrary.org/obo/BFO_0000004> or OEO_00000139),
+        OEO_00020180 some OEO_00040003
     
     
 Class: OEO_00010130
@@ -782,8 +779,8 @@ Class: OEO_00010491
 
     EquivalentTo: 
         OEO_00000331
-         and (OEO_00240025 some OEO_00050000)
          and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00040011)
+         and (OEO_00240025 some OEO_00050000)
     
     
 Class: OEO_00020011
@@ -848,13 +845,13 @@ Class: OEO_00020186
 Class: OEO_00020201
 
     SubClassOf: 
-        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
+        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002418> some OEO_00140124)
     
     
 Class: OEO_00020202
 
     SubClassOf: 
-        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
+        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002418> some OEO_00140124)
     
     
 Class: OEO_00020227
@@ -1022,8 +1019,8 @@ Class: OEO_00240026
 
     EquivalentTo: 
         OEO_00000331
-         and (OEO_00240025 some OEO_00050000)
          and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00010117)
+         and (OEO_00240025 some OEO_00050000)
     
     
 Class: OEO_00240027
@@ -1090,6 +1087,9 @@ Class: OEO_00260007
 
     
 Class: OEO_00320021
+
+    
+Class: OEO_00330023
 
     
 Individual: OEO_00010042

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -123,6 +123,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0000087>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002410>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002418>
+
+    
 ObjectProperty: OEO_00000501
 
     
@@ -671,7 +674,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
-        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002410> some OEO_00140124)
+        (<http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010116) or (<http://purl.obolibrary.org/obo/RO_0002418> some OEO_00140124)
     
     
 Class: OEO_00010212


### PR DESCRIPTION
## Summary of the discussion

As discussed in #2105, the RO property `causally related to` shouldn't be used directly.

## Type of change (CHANGELOG.md)

### Update
- `export`, `import`, `distribution`
    - changed the subclass axiom `'causally related to' some 'service'` to `'causally upstream of or within' some 'service'` 

## Workflow checklist

### Automation
Closes #2105

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
