### PR TITLE
Add delayed transition scenario #2101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - RO import: regulates characteristic, positively regulates characteristic, negatively regulates (#2094)
 - voltage classification system, german voltage classification system (#2042)
 - electricity grid voltage level, low electricity grid voltage level, medium electricity grid voltage level, high electricity grid voltage level, extra high electricity grid voltage level (#2042)
+- delayed transition scenario (#2116)
 
 ### Changed
 - air, water, biomass, biofuel, nuclear fuel (#2095)

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4015,7 +4015,7 @@ Class: OEO_00390105
         rdfs:label "delayed transition scenario"@en,
         OEO_00020426 "add:
 Issue: https://github.com/OpenEnergyPlatform/ontology/issues/2101
-Pull Request:"
+Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/2116"
     
     SubClassOf: 
         OEO_00000364

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4018,7 +4018,7 @@ Issue: https://github.com/OpenEnergyPlatform/ontology/issues/2101
 Pull Request: https://github.com/OpenEnergyPlatform/ontology/pull/2116"
     
     SubClassOf: 
-        OEO_00000364
+        OEO_00020248
     
     
 Class: OEO_00400012

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4008,6 +4008,19 @@ Pull: https://github.com/OpenEnergyPlatform/ontology/pull/2091"
         OEO_00020166
     
     
+Class: OEO_00390105
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A delayed transition scenario is an explorative scenario whose intermediate transition indicators are not achieved.",
+        rdfs:label "delayed transition scenario"@en,
+        OEO_00020426 "add:
+Issue: https://github.com/OpenEnergyPlatform/ontology/issues/2101
+Pull Request:"
+    
+    SubClassOf: 
+        OEO_00000364
+    
+    
 Class: OEO_00400012
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

See #2101. The delayed transition scenario is added as an explorative scenario.

## Type of change (CHANGELOG.md)

### Add
- delayed transition scenario


### Automation
Closes #2101

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
