### PR TITLE
Remove doaim and range from regulates characteristic #2117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - 'target description' renamed to 'legal target description' (#2102)
 - 'goal description' made a subclass of 'objective specification' (#2102)
 - electricity grid (#2042)
+- regulates characteristic (#2118)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -433,7 +433,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2094
 
 Remove domain/range:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2117
-pull request:</oeo:OEO_00020426>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2118</oeo:OEO_00020426>
     </owl:ObjectProperty>
     
 

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -427,11 +427,13 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1136</oeo:OEO_
     <!-- http://purl.obolibrary.org/obo/RO_0019000 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0019000">
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
-        <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/BFO_0000019"/>
         <oeo:OEO_00020426>import from RO
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2053
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2094</oeo:OEO_00020426>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2094
+
+Remove domain/range:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2117
+pull request:</oeo:OEO_00020426>
     </owl:ObjectProperty>
     
 


### PR DESCRIPTION
## Summary of the discussion

See #2117. Domain and range were removed from `regulates characteristic`

## Type of change (CHANGELOG.md)


### Update
- `regulates characteristic`


## Workflow checklist

### Automation
Closes #2117

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
