### PR TITLE
Add simulation scenario concept #2071

### DIFF
--- a/src/ontology/edits/oeo-co-sim.omn
+++ b/src/ontology/edits/oeo-co-sim.omn
@@ -3,7 +3,6 @@ Prefix: dc: <http://purl.org/dc/elements/1.1/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Prefix: rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-Prefix: skos: <http://www.w3.org/2004/02/skos/core#>
 Prefix: xml: <http://www.w3.org/XML/1998/namespace>
 Prefix: xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -18,6 +17,15 @@ Annotations:
     <http://purl.org/dc/terms/license> "http://creativecommons.org/publicdomain/zero/1.0/",
     <http://purl.org/dc/terms/title> "Open Energy Ontology (Co-Simulation module)"
 
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
+
+    
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000118>
+
+    
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
+
+    
 AnnotationProperty: <http://purl.org/dc/terms/license>
 
     
@@ -25,6 +33,9 @@ AnnotationProperty: <http://purl.org/dc/terms/title>
 
     
 AnnotationProperty: dc:description
+
+    
+AnnotationProperty: rdfs:comment
 
     
 AnnotationProperty: rdfs:label
@@ -35,4 +46,57 @@ Datatype: rdf:PlainLiteral
     
 Datatype: xsd:string
 
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
+
+    
+Class: <http://purl.obolibrary.org/obo/IAO_0000005>
+
+    
+Class: <http://purl.obolibrary.org/obo/IAO_0000104>
+
+    
+Class: <https://openenergyplatform.org/ontology/oeo/OEO_00420000>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation scenario is a plan specification that references a simulation configuration and contains simulation objective specifications to motivate the planned analysis.",
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Simulationsszenario"@de,
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2071
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2xxx",
+        rdfs:comment "The bearer of the simulation scenario is the researcher, starting the simulation and analysing the results.",
+        rdfs:label "simulation scenario"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <https://openenergyplatform.org/ontology/oeo/OEO_00420001>
+    
+    
+Class: <https://openenergyplatform.org/ontology/oeo/OEO_00420001>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation configuration is a plan specification that describes the technical setup containing simulation components, their connections, and all the exogeneous data necessary to be realized in a simulation process.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2071
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2xxx",
+        rdfs:comment "The bearer of the simulation configuration is the simulation framework realizing the simulation configuration in the simulation.",
+        rdfs:label "simulation configuration"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000104>,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some <https://openenergyplatform.org/ontology/oeo/OEO_00420002>
+    
+    
+Class: <https://openenergyplatform.org/ontology/oeo/OEO_00420002>
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An output creation objective is an objective specification that defines the goal to produce output data.",
+        <http://purl.obolibrary.org/obo/IAO_0000233> "add
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2071
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2xxx",
+        rdfs:label "output creation objective"@en
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000005>
+    
     


### PR DESCRIPTION
## Summary of the discussion

Add concept for description of simulation scenarios.

closes #2071 

## Type of change (CHANGELOG.md)

### Add
- Added new classes `simulation scenario`, `simulation configuration`, and `create output objective` [#2071](https://github.com/OpenEnergyPlatform/ontology/issues/2071)

### Update

### Remove

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
