### PR TITLE
bug fix: correct duplicate definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - electricity grid (#2042)
 - electricity grid voltage level, electricity grid component (#2108)
 - based on sector division, covers technology (shortcut), covers energy carrier (shortcut), has informarion input (shortcut), has information ouputt (shortcut) (#2122)
+- has squared / linear unit denominator, RED sector transport, EU emission sector LULUCF (#2126)
 
 
 ### Removed

--- a/src/ontology/edits/oeo-sector.omn
+++ b/src/ontology/edits/oeo-sector.omn
@@ -1939,7 +1939,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724"
 Individual: OEO_00010135
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector ETS stationary is a sector defined by an EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by stationary installations.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The EU emission sector LULUCF is a sector defined by an EU emission sector division that covers greenhouse gas emissions regulated by the European Union Emissions Trading System and that are emitted by agriculture, forestry and land use.",
         rdfs:label "EU emission sector: LULUCF"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/834
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/857
@@ -1950,7 +1950,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1462
 
 move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724
+
+correct definition
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1726"
     
     Types: 
         OEO_00010035,

--- a/src/ontology/edits/oeo-sector.omn
+++ b/src/ontology/edits/oeo-sector.omn
@@ -4385,14 +4385,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724"
 Individual: OEO_00010391
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "The RED sector heating and cooling is a heating and cooling sector defined by the Renewable Energy Directive sector division.",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "The RED sector transport is a transport sector defined by the Renewable Energy Directive sector division.",
         rdfs:label "RED sector: transport"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1443
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1446
 
 move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724
+
+correct definition
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2126"
     
     Types: 
         OEO_00000422

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -837,14 +837,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816"
 ObjectProperty: OEO_00010477
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 1."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the denominator of unit A with exponent 1."@en,
         <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit is composed of at least two other units. Examples are:
 m/s has a linear numerator metre and a linear denominator second.
 kg/m³ has a linear numerator kilogram and a cubed denominator metre.
 Wh has two linear numerators: Watt and hour",
         rdfs:label "has linear unit denominator"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816
+correct definition
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2126"
     
     SubPropertyOf: 
         OEO_00010476

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -866,14 +866,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816"
 ObjectProperty: OEO_00010478
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the numerator of unit A with exponent 2."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a (composed) unit A and a unit B in which B is in the denominator of unit A with exponent 2."@en,
         <http://purl.obolibrary.org/obo/IAO_0000600> "A composed unit is composed of at least two other units. Examples are:
 m/s has a linear numerator metre and a linear denominator second.
 kg/m³ has a linear numerator kilogram and a cubed denominator metre.
 Wh has two linear numerators: Watt and hour",
         rdfs:label "has squared unit denominator"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1815
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1816
+correct definition
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2126"
     
     SubPropertyOf: 
         OEO_00010476


### PR DESCRIPTION
## Summary of the discussion

In #2113 we found a couple of duplicate definitions, probably accidentially added via copy and paste. Because these are some minor changes, I corrected them here without separate issue.

## Type of change (CHANGELOG.md)


### Update
Updated definition of:
- `has squared / linear unit denominator` -- replaced "numerator" with "denominator"
- `RED sector transport` -- replace "heating and cooling" with "transport"
- `EU emission sector LULUCF` -- replace "ETS stationary" with "LULUCF"

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
