### PR TITLE
Include full ontology files in release #2150

### DIFF
--- a/.github/workflows/PostReleaseScripts.yml
+++ b/.github/workflows/PostReleaseScripts.yml
@@ -125,6 +125,9 @@ jobs:
           cd src/scripts/etd/glossary
           zip -r ../../../../existing-terms-and-definitions.zip ./
           cd ../../../..
+      - name: Copy built ontology files to workspace
+        run: |
+          find build/oeo/ -maxdepth 2 -name "oeo-full.*" -exec cp {} ${{ github.workspace }} \;
       - name: Attach artifacts to release
         uses: ncipollo/release-action@v1
         with:
@@ -141,4 +144,4 @@ jobs:
           # We don't want this behaviour, as releases created as draft or pre-release won't be updated in that regard and therefore result in
           # unconsistent behaviour when creating normal releases vs. draft or pre-releases.
           makeLatest: false
-          artifacts: "${{ github.workspace }}/build-files.zip,${{ github.workspace }}/existing-terms-and-definitions.zip"
+          artifacts: "${{ github.workspace }}/build-files.zip,${{ github.workspace }}/existing-terms-and-definitions.zip,${{ github.workspace }}/oeo-full.omn,${{ github.workspace }}/oeo-full.owl"


### PR DESCRIPTION
## Summary of the discussion

The build releases are not accessible directly via the GitHub release. For an easier access, the oeo-full version should be attached to releases separately. We choose the full version instead of the modularized ontologies to better browse through past releases.

## Type of change (CHANGELOG.md)

- `oeo-full.owl` and `oeo-full.omn` are attached to releases separately. (see https://github.com/b-gehrke/oeo/releases/tag/v2.9.0 as an example)
- No changes related to the contents of the ontology

## Workflow checklist

### Automation
Closes #2150

### PR-Assignee
- [X] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
