### PR TITLE
Add property chains for shortcut relations #2215

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 
 ### Added
 ### Changed
+- covers sector (shortcut), covers technology (shortcut), covers energy carrier (shortcut) #2216
 ### Removed
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ For each version, important additions, changes and removals are listed here.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/),
 and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [2.X.X] - 20XX-XX-XX
+
+### Added
+### Changed
+### Removed
+
+
 ## [2.11.0] - 2026-03-04
 
 ### Added

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -301,6 +301,9 @@ ObjectProperty: OEO_00020190
     
 ObjectProperty: OEO_00020432
 
+    SubPropertyChain: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> o OEO_00000523
+    
     Domain: 
         OEO_00020227
     

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -337,6 +337,9 @@ ObjectProperty: OEO_00020439
     SubPropertyOf: 
         owl:topObjectProperty
     
+    SubPropertyChain: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> o OEO_00000505
+    
     Domain: 
         OEO_00020227
     

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -322,6 +322,9 @@ ObjectProperty: OEO_00020437
     
 ObjectProperty: OEO_00020438
 
+    SubPropertyChain: 
+        <http://purl.obolibrary.org/obo/IAO_0000136> o OEO_00390101
+    
     Domain: 
         OEO_00020227
     
@@ -379,6 +382,9 @@ ObjectProperty: OEO_00390079
     Range: 
         OEO_00000368
     
+    
+ObjectProperty: OEO_00390101
+
     
 ObjectProperty: owl:topObjectProperty
 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1122,7 +1122,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2122
 
 move domain and range to oeo-shared-axioms
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2119
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2195",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2195
+
+add property chain
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2215
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2216",
         OEO_00020434 "SELECT ?scenariobundle ?energycarrier WHERE {
 ?scenariobundle IAO:0000136 _:1.
 _:1 OEO:00000523 ?energycarrier.

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1233,6 +1233,20 @@ _:1 OEO:00390101 ?technology.
         OEO_00000407
     
     
+ObjectProperty: OEO_00020439
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a scenario bundle and a sector that is covered by the study the scenario bundle is about. It is a shortcut relation, see elucidation and associated sparql axiom.",
+        <http://purl.obolibrary.org/obo/IAO_0000600> "This is a shortcut relation to relate 'scenario bundle' to 'sector'. The original relation 'covers sector' relates 'study' (process) to 'sector'. 
+The shortcut relation should be used to represents these statements:
+('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers sector' some 'sector')",
+        rdfs:label "covers sector (shortcut)",
+        OEO_00020434 "SELECT ?scenariobundle ?sector WHERE {
+?scenariobundle IAO:0000136 _:1.
+_:1 OEO:00390101 ?sector.
+}"
+    
+    
 ObjectProperty: OEO_00040010
 
     Annotations: 

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1241,6 +1241,9 @@ ObjectProperty: OEO_00020439
 The shortcut relation should be used to represents these statements:
 ('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers sector' some 'sector')",
         rdfs:label "covers sector (shortcut)",
+        OEO_00020426 "reconstruct and add property chain
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2215
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2216",
         OEO_00020434 "SELECT ?scenariobundle ?sector WHERE {
 ?scenariobundle IAO:0000136 _:1.
 _:1 OEO:00390101 ?sector.

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1212,7 +1212,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2122
 
 move domain and range to oeo-shared-axioms
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2119
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2195",
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2195
+
+add property chain
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2215
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2216",
         OEO_00020434 "SELECT ?scenariobundle ?technology WHERE {
 ?scenariobundle IAO:0000136 _:1.
 _:1 OEO:00390101 ?technology.

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1246,7 +1246,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/2215
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2216",
         OEO_00020434 "SELECT ?scenariobundle ?sector WHERE {
 ?scenariobundle IAO:0000136 _:1.
-_:1 OEO:00390101 ?sector.
+_:1 OEO:00000505 ?sector.
 }"
     
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -1241,7 +1241,9 @@ ObjectProperty: OEO_00020439
 The shortcut relation should be used to represents these statements:
 ('scenario bundle 'is about' some 'scenario study'`) and ('scenario study' 'covers sector' some 'sector')",
         rdfs:label "covers sector (shortcut)",
-        OEO_00020426 "reconstruct and add property chain
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2013
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2023
+reconstruct and add property chain
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2215
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2216",
         OEO_00020434 "SELECT ?scenariobundle ?sector WHERE {


### PR DESCRIPTION
## Summary of the discussion
based on #2215
- Add property chains to the shortcut relations `covers technology (shortcut)`, `covers energy carrier (shortcut)`, `covers sector (shortcut)`
- Add the annotations for `covers sector (shortcut)` have been lost
## Type of change (CHANGELOG.md)

### Update
- `covers technology (shortcut)`
- `covers energy carrier (shortcut)`
- `covers sector (shortcut)`


## Workflow checklist

### Automation
Closes #2215

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
