### PR TITLE
Update issue template for new ontology terms

### DIFF
--- a/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
+++ b/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
@@ -16,7 +16,7 @@ Please fill out as much of the list below as you can for each entity you wish to
 - **Proposed Label**: [The primary term that is used to refer to the entity. Please follow the ENERO Foundry principle on [Naming Conventions](https://enerofoundry.github.io/ENEROFoundry/principles/8_naming/).]
 - **Potential Synonyms**: [Any alternative terms that can also be used to refer to the entity. Please follow the ENERO Foundry principle on [Naming Conventions](https://enerofoundry.github.io/ENEROFoundry/principles/8_naming/).]
 - **Proposed Superclass**: [an existing term in OEO]
-- **Proposed Definition**: A [proposed entity] is a [proposed superclass] that is [specify what distinguishes the proposed entity from other entities of this kind].
+- **Proposed Definition**: A [proposed entity] is a [proposed superclass] that is [specify what distinguishes the proposed entity from other entities of this kind]. [Please refer to the ENERO Foundry principle on [Textual Definitions](https://enerofoundry.github.io/ENEROFoundry/principles/9_definitions/).]
 - **Definition Sources/References**: [links to any reference material that can help others better understand the entity]
 - **Other Information**:
     - What differentiates the proposed entity from other entities of the proposed superclass?

--- a/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
+++ b/.github/ISSUE_TEMPLATE/-a--new-ontology-term.md
@@ -7,13 +7,21 @@ assignees: ''
 
 ---
 
-## Description of the issue
+## Template Instructions
 
-Here describe the issue as extensively as possible
+Please fill out as much of the list below as you can for each entity you wish to suggest for inclusion in the OEO. It isn't mandatory to complete every bullet point, but the more information is provided, the easier it will be for other developers to evaluate your suggestion.
 
-## Ideas of solution
+## Proposed New Ontology Entity
 
-If you already have ideas for the solution describe them here
+- **Proposed Label**: [The primary term that is used to refer to the entity. Please follow the ENERO Foundry principle on [Naming Conventions](https://enerofoundry.github.io/ENEROFoundry/principles/8_naming/).]
+- **Potential Synonyms**: [Any alternative terms that can also be used to refer to the entity. Please follow the ENERO Foundry principle on [Naming Conventions](https://enerofoundry.github.io/ENEROFoundry/principles/8_naming/).]
+- **Proposed Superclass**: [an existing term in OEO]
+- **Proposed Definition**: A [proposed entity] is a [proposed superclass] that is [specify what distinguishes the proposed entity from other entities of this kind].
+- **Definition Sources/References**: [links to any reference material that can help others better understand the entity]
+- **Other Information**:
+    - What differentiates the proposed entity from other entities of the proposed superclass?
+    - What would be an example of usage/instance of this entity?
+    - What are potential subclasses of the proposed entity?
 
 ## Workflow checklist
 
@@ -24,3 +32,4 @@ If you already have ideas for the solution describe them here
 I am aware that
 - [ ] every entry in the ontology should have a definition
 - [ ] classes should arise from concepts rather than from words
+- [ ] any ontology content that is proposed in this issue may be altered as needed to fit the structure and conventions of the OEO


### PR DESCRIPTION
## Summary of the discussion

Based on the discussion in the 27.03 dev meeting (https://etherpad.wikimedia.org/p/oeo-dev-118), the template for creating an issue to suggest a new term for the OEO has been updated.

## Type of change (CHANGELOG.md)

### Update
- Updated issue template

## Workflow checklist

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
