### PR TITLE
add oeo-idranges.owl #2223

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 ## [unreleased] - 20XX-XX-XX
 
 ### Added
+- oeo-idranges.owl (#2225)
 
 ### Changed
 - covers sector (shortcut), covers technology (shortcut), covers energy carrier (shortcut) #2216

--- a/src/ontology/oeo-idranges.owl
+++ b/src/ontology/oeo-idranges.owl
@@ -41,7 +41,7 @@ Datatype: idrange:1
 Datatype: idrange:2
 
     Annotations:
-		allocatedto: "Mirjam Stappel"
+		allocatedto: "mstap"
     
     EquivalentTo: 
         xsd:integer[>= 20461 , <= 29999]
@@ -81,6 +81,15 @@ Datatype: idrange:6
     
     EquivalentTo: 
         xsd:integer[>= 440003 , <= 449999]
+		
+		
+Datatype: idrange:7
+
+    Annotations: 
+        allocatedto: "Jan Sören Schwarz"
+    
+    EquivalentTo: 
+        xsd:integer[>= 420004 , <= 429999]
     
     
 Datatype: xsd:integer

--- a/src/ontology/oeo-idranges.owl
+++ b/src/ontology/oeo-idranges.owl
@@ -50,7 +50,7 @@ Datatype: idrange:2
 Datatype: idrange:3
 
     Annotations: 
-        allocatedto: "Ludwig Huelk"
+        allocatedto: "Ludwig Hülk"
     
     EquivalentTo: 
         xsd:integer[>= 110021 , <= 119999]


### PR DESCRIPTION
## Summary of the discussion

Add oeo-idranges.owl

With this file, protege should recognize that there are user settings stored for editing OEO. When opening protege, a small window should appear where you should be able to select your user name. The settings for your user should be automatically updated. This allows to have several user IDs for several ontologies, e.g. OEO, CEPO, MUNO, MHPO etc.

## Type of change (CHANGELOG.md)

### Add
- oeo-idranges.owl [#2225](https://github.com/OpenEnergyPlatform/ontology/issues/2225)

## Workflow checklist

### Automation
Closes #2223

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [x] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
