### PR TITLE
fix term tracker annotation of robust system scenario #2204

### DIFF
--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3017,11 +3017,11 @@ Class: OEO_00020411
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A robust system scenario is an explorative scenario that describes an energy system that is designed to evolve in a robust way.",
-        <http://purl.obolibrary.org/obo/IAO_0000118> "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1683
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1843",
         <http://purl.obolibrary.org/obo/IAO_0000118> "robust investment decision",
         <http://purl.obolibrary.org/obo/IAO_0000118> "robust transformation pathway",
-        rdfs:label "robust system scenario"
+        rdfs:label "robust system scenario",
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1683
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1843"
     
     SubClassOf: 
         OEO_00020248


### PR DESCRIPTION
## Summary of the discussion

fix term tracker annotation of `robust system scenario` (formally accidentally annotated as alternative term)
closes #2204
The changes are that minor that I don't add a changelog nor term trackers.


## Workflow checklist

### Automation
Closes #2204 

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [x] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
