### PR TITLE
Add property chains #2190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - oeo-idranges.owl (#2225)
 - hydrogen boiler, biomass boiler, natural gas boiler, oil boiler (#2226)
 - add german translations for hydrogen color labels (#2222)
-- Add property `decreases energy` (#2232)
-- Add property `increases energy` (#2232)
+- Object property `decreases energy` and `increases energy` (#2232)
 
 ### Changed
 - covers sector (shortcut), covers technology (shortcut), covers energy carrier (shortcut) #2216

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 
 ### Added
 - oeo-idranges.owl (#2225)
-- hydrogen boiler, biomass boiler, naturl gas boiler, oil boiler (#2226)
+- hydrogen boiler, biomass boiler, natural gas boiler, oil boiler (#2226)
 - add german translations for hydrogen color labels (#2222)
+- Add property `decreases energy` (#2232)
+- Add property `increases energy` (#2232)
 
 ### Changed
 - covers sector (shortcut), covers technology (shortcut), covers energy carrier (shortcut) #2216

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -682,7 +682,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2232"
         owl:topObjectProperty
     
     SubPropertyChain: 
-        <http://purl.obolibrary.org/obo/BFO_0000117> o <http://purl.obolibrary.org/obo/RO_0019002>
+        <http://purl.obolibrary.org/obo/BFO_0000117> o <http://purl.obolibrary.org/obo/RO_0019001>
     
     Domain: 
         <http://purl.obolibrary.org/obo/BFO_0000015>

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -669,6 +669,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
 ObjectProperty: OEO_00020404
 
     
+ObjectProperty: OEO_00020461
+
+    Annotations: 
+        rdfs:label "increases energy"@de
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    
+ObjectProperty: OEO_00020462
+
+    Annotations: 
+        rdfs:label "decreases energy"@de
+    
+    SubPropertyOf: 
+        owl:topObjectProperty
+    
+    
 ObjectProperty: OEO_00040010
 
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -672,10 +672,23 @@ ObjectProperty: OEO_00020404
 ObjectProperty: OEO_00020461
 
     Annotations: 
-        rdfs:label "increases energy"@de
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy transformation process or energy transfer process (p) and a subtype of energy (e), where (e) is positively regulated by an energy increase process (i) as subprocess of (p)."@en,
+        rdfs:label "increases energy"@en,
+        OEO_00020426 "add
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2232"
     
     SubPropertyOf: 
         owl:topObjectProperty
+    
+    SubPropertyChain: 
+        <http://purl.obolibrary.org/obo/BFO_0000117> o <http://purl.obolibrary.org/obo/RO_0019002>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00020462

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -681,10 +681,23 @@ ObjectProperty: OEO_00020461
 ObjectProperty: OEO_00020462
 
     Annotations: 
-        rdfs:label "decreases energy"@de
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy transformation process or energy transfer process (p) and a subtype of energy (e), where (e) is negatively regulated by an energy decrease process (d) as subprocess of (p)."@en,
+        rdfs:label "decreases energy"@en,
+        OEO_00020426 "add
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2232"
     
     SubPropertyOf: 
         owl:topObjectProperty
+    
+    SubPropertyChain: 
+        <http://purl.obolibrary.org/obo/BFO_0000117> o <http://purl.obolibrary.org/obo/RO_0019002>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00040010


### PR DESCRIPTION
## Summary of the discussion

As first step of #2190 we add two object properties: `increases energy` and `decreases energy` as property chains of `has occurrent part` o `positively / negatively regulates energy`


## Type of change (CHANGELOG.md)

### Add
- Add property `decreases energy` [(#2232)](https://github.com/OpenEnergyPlatform/ontology/issues/2232)
- Add property `increases energy` [(#2232)](https://github.com/OpenEnergyPlatform/ontology/issues/2232)

## Workflow checklist

### Automation
part of #2190 
### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
