### PR TITLE
Remove infering CassAssertions for oeo-closure #2237

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,5 +109,5 @@ $(VERSIONDIR)/oeo-full.omn : $(VERSIONDIR)/oeo-full.owl
 	$(call replace_owls,$@)
 
 $(VERSIONDIR)/oeo-closure.owl : $(VERSIONDIR)/oeo-full.owl
-	$(ROBOT) reason --input $< --reasoner hermit --catalog $(VERSIONDIR)/catalog-v001.xml --axiom-generators "SubClass EquivalentClass DataPropertyCharacteristic EquivalentDataProperties SubDataProperty ClassAssertion EquivalentObjectProperty InverseObjectProperties ObjectPropertyCharacteristic SubObjectProperty ObjectPropertyRange ObjectPropertyDomain" --include-indirect true annotate --ontology-iri https://openenergyplatform.org/ontology/oeo/ --output $@
+	$(ROBOT) reason --input $< --reasoner hermit --catalog $(VERSIONDIR)/catalog-v001.xml --axiom-generators "SubClass EquivalentClass DataPropertyCharacteristic EquivalentDataProperties SubDataProperty EquivalentObjectProperty InverseObjectProperties ObjectPropertyCharacteristic SubObjectProperty ObjectPropertyRange ObjectPropertyDomain" --include-indirect true annotate --ontology-iri https://openenergyplatform.org/ontology/oeo/ --output $@
 	$(ROBOT) merge --catalog $(VERSIONDIR)/catalog-v001.xml --input $< --input $@ annotate --ontology-iri https://openenergyplatform.org/ontology/oeo/ --output $@


### PR DESCRIPTION
## Summary of the discussion

Notes from oeo-dev meeting 119:
- Release 2.11.0 on TIB TS: 
    - shows now oeo-closure
        - individuals have complete hierarchy as type; result: all instances appear under "entity" etc.
        - make some changes in the makefile to seelct which axioms are inferred (e.g. only non-trivial ones) - have a meeting before the next release (during the release)
            - exclude class assertions for individuals (https://robot.obolibrary.org/reason#generated-axioms, https://github.com/OpenEnergyPlatform/ontology/blob/f1cad4e36d622f933dd63f42bed10ed3730a68c3/Makefile#L112)
                - *Finding*: Works well
            - robot reduce command (https://robot.obolibrary.org/reduce)
                - *Finding*: Takes too long when done with hermit, does not remove ClassAsertions when done with ELK

## Type of change (CHANGELOG.md)

### Add

### Update
- Updated Makefile rule for oeo-closure

### Remove

## Workflow checklist

### Automation
Closes #2237

### PR-Assignee
- [X] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [-] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [-] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
