### PR TITLE
change label and add synonym for CRF sector division #2247

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 
 ### Added
 ### Changed
+- change label: common reporting format / CRF sector division (#2248)
 ### Removed
 
 ## [2.12.0] - 2026-05-04

--- a/src/ontology/edits/oeo-sector.omn
+++ b/src/ontology/edits/oeo-sector.omn
@@ -624,7 +624,8 @@ Class: OEO_00010055
         <http://purl.obolibrary.org/obo/IAO_0000118> "CRF",
         <http://purl.obolibrary.org/obo/IAO_0000118> "NIR sector division",
         <http://purl.obolibrary.org/obo/IAO_0000118> "national inventory report sector division",
-        rdfs:label "common reporting format"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "common reporting format",
+        rdfs:label "CRF sector division"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/461
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/578
 
@@ -634,7 +635,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1558
 
 move to oeo-sector 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1399
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1724
+
+change label and add synonym
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2247
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2248"
     
     SubClassOf: 
         OEO_00000368


### PR DESCRIPTION
## Summary of the discussion

closes #2248

## Type of change (CHANGELOG.md)

### Update
- change label: CRF sector division / common reporting format


### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
