### PR TITLE
remove `is energy participant of` #2190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 ### Changed
 - change label: common reporting format / CRF sector division (#2248)
 - change axiom: power-to-fuel technology and subclasses (#2250)
+- remove axiom: electrical energy, solar electrical energy, hydro energy, marine current/tidal/wave energy, wind energy, industrial waste thermal energy (#2256)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6110,16 +6110,14 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
 
 add and change axioms
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+
+remove is energy participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2256"
     
     SubClassOf: 
-        OEO_00020087,
-        
-            Annotations: OEO_00020426 "change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00010107,
-        OEO_00020183 some OEO_00010098
+        OEO_00020087
     
     
 Class: OEO_00010098

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9009,11 +9009,11 @@ Class: OEO_00010419
         <http://purl.obolibrary.org/obo/IAO_0000115> "Solar electrical energy is electrical energy that is energy output of a solar energy transformation.",
         rdfs:label "solar electrical energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559"
-    
-    EquivalentTo: 
-        OEO_00000139
-         and (OEO_00020184 some OEO_00020046)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559
+
+remove is energy participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2256"
     
     SubClassOf: 
         OEO_00000139,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3356,19 +3356,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1620
 
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928
+
+remove is energy participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2256"
     
     SubClassOf: 
         OEO_00230020,
-        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441,
-        
-            Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
-
-change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00110002
+        <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000441
     
     
 Class: OEO_00000219

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2561,12 +2561,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1395
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+remove is energy participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2256"
     
     SubClassOf: 
-        OEO_00000150,
-        OEO_00020182 some OEO_00020207,
-        OEO_00020182 some OEO_00020208
+        OEO_00000150
     
     
 Class: OEO_00000143

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6200,11 +6200,14 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
 
 change axiom from participates in to is energy participant of
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+
+remove is energy participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2256"
     
     SubClassOf: 
-        OEO_00020087,
-        OEO_00020182 some OEO_00010101
+        OEO_00020087
     
     
 Class: OEO_00010101
@@ -6238,15 +6241,14 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
 
 change axiom from participates in to is energy participant of
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+
+remove is energy participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2256"
     
     SubClassOf: 
-        OEO_00020087,
-        
-            Annotations: OEO_00020426 "change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00010106
+        OEO_00020087
     
     
 Class: OEO_00010103

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -14611,11 +14611,14 @@ Class: OEO_00310004
         <http://purl.obolibrary.org/obo/IAO_0000118> "industrielle Abwärme"@de,
         rdfs:label "industrial waste thermal energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1265
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1359
+
+remove is energy participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2256"
     
     SubClassOf: 
-        OEO_00010114,
-        OEO_00020184 some OEO_00050000
+        OEO_00010114
     
     
 Class: OEO_00310005

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3348,8 +3348,17 @@ Class: OEO_00000218
         rdfs:label "hydro energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/679
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/681
+
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/
+
 change axiom from participates in to is energy participant of
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+
 added axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1600
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1620
@@ -4909,20 +4918,30 @@ Class: OEO_00000446
         rdfs:label "wind energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/211
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/225
+
 reclassify and change def
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/662
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/666
+
 remove disposition renewable fuel
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/726
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/732
+
+change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/
+
 add and change axioms
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+
 added axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1600
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1620
+
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928
+
 remove is energy participant axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2256"
@@ -6102,6 +6121,10 @@ Class: OEO_00010097
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
 
+change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/
+
 fix classification:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/896
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/921
@@ -6232,6 +6255,10 @@ Class: OEO_00010102
         rdfs:label "marine wave energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/762
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/806
+
+change axiom to 'participates in'
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/
 
 fix classification:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/896

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -4922,18 +4922,15 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1600
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1620
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928
+remove is energy participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2256"
     
     SubClassOf: 
         OEO_00230020,
         <http://purl.obolibrary.org/obo/RO_0000052> some OEO_00000054,
-        OEO_00000530 some OEO_00030004,
-        
-            Annotations: OEO_00020426 "change axiom to 'participates in'
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/850
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/871/"
-        OEO_00020182 some OEO_00000043,
-        OEO_00020183 some OEO_00020043
+        OEO_00000530 some OEO_00030004
     
     
 Class: OEO_00000447


### PR DESCRIPTION
## Summary of the discussion

Follow-up on #2190 
After removing all axioms with `has energy participant`, this PR is about removing all usages of `is energy participant of`.

## Type of change (CHANGELOG.md)

### Update
- remove axiom: electrical energy, solar electrical energy, hydro energy, marine current/tidal/wave energy, wind energy, industrial waste thermal energy

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
