### PR TITLE
add subclasses of `heat generation unit / plant` #2159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 
 ### Added
 - ethen (#2260)
+- agricultural waste fuel, coal refuse (#2261)
+- biomass heat unit, oil heat unit, hydrogen heat unit, (natural) gas heat unit, biomass heat plant, oil heat plant, hydrogen heat plant, gas heat plant (#2262)
 
 ### Changed
 - change label: common reporting format / CRF sector division (#2248)
 - change axiom: power-to-fuel technology and subclasses (#2250)
 - remove axiom: electrical energy, solar electrical energy, hydro energy, marine current/tidal/wave energy, wind energy, industrial waste thermal energy (#2256)
+- add alternative label: colliery gas, lignite (#2261)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11614,6 +11614,17 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2260",
         OEO_00000529 value OEO_00000182
     
     
+Class: OEO_00020497
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biomass heat unit is a heat generating unit that has a boiler and uses biomass as a fuel input."@en,
+        rdfs:label "biomass heat unit"@en
+    
+    SubClassOf: 
+        OEO_00310008,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00310013
+    
+    
 Class: OEO_00030000
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11656,7 +11656,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
 Class: OEO_00020500
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas heat unit is a heat generating unit that has a boiler and uses natural gas as a fuel input."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas heat unit is a heat generating unit that has a boiler and uses methane as a fuel input."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "natural gas heat unit",
         rdfs:label "gas heat unit"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2159

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11643,7 +11643,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
 Class: OEO_00020499
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A oil heat unit is a heat generating unit that has a boiler and uses oil as a fuel input."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil heat unit is a heat generating unit that has a boiler and uses oil as a fuel input."@en,
         rdfs:label "oil heat unit"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2159
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
@@ -11672,6 +11672,19 @@ Class: OEO_00020501
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biomass heat plant is a heat plant that has biomass heat units as parts.",
         rdfs:label "biomass heat plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2159
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
+    
+    SubClassOf: 
+        OEO_00310011,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020497
+    
+    
+Class: OEO_00020502
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "An oil heat plant is a heat plant that has oil heat units as parts.",
+        rdfs:label "oil heat plant"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2159
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11618,7 +11618,22 @@ Class: OEO_00020497
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A biomass heat unit is a heat generating unit that has a boiler and uses biomass as a fuel input."@en,
-        rdfs:label "biomass heat unit"@en
+        rdfs:label "biomass heat unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2159
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
+    
+    SubClassOf: 
+        OEO_00310008,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00310013
+    
+    
+Class: OEO_00020498
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen heat unit is a heat generating unit that has a boiler and uses hydrogen as a fuel input."@en,
+        rdfs:label "hydrogen heat unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2159
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
     
     SubClassOf: 
         OEO_00310008,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11667,6 +11667,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00310013
     
     
+Class: OEO_00020501
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A biomass heat plant is a heat plant that has biomass heat units as parts.",
+        rdfs:label "biomass heat plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2159
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
+    
+    SubClassOf: 
+        OEO_00310011,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020497
+    
+    
 Class: OEO_00030000
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11653,6 +11653,20 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00310013
     
     
+Class: OEO_00020500
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas heat unit is a heat generating unit that has a boiler and uses natural gas as a fuel input."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "natural gas heat unit",
+        rdfs:label "gas heat unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2159
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
+    
+    SubClassOf: 
+        OEO_00310008,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00310013
+    
+    
 Class: OEO_00030000
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11640,6 +11640,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00310013
     
     
+Class: OEO_00020499
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A oil heat unit is a heat generating unit that has a boiler and uses oil as a fuel input."@en,
+        rdfs:label "oil heat unit"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2159
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
+    
+    SubClassOf: 
+        OEO_00310008,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00310013
+    
+    
 Class: OEO_00030000
 
     Annotations: 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -11690,7 +11690,33 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
     
     SubClassOf: 
         OEO_00310011,
-        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020497
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020499
+    
+    
+Class: OEO_00020503
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hydrogen heat plant is a heat plant that has hydrogen heat units as parts.",
+        rdfs:label "hydrogen heat plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2159
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
+    
+    SubClassOf: 
+        OEO_00310011,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020498
+    
+    
+Class: OEO_00020504
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A gas heat plant is a heat plant that has gas heat units as parts.",
+        rdfs:label "gas heat plant"@de,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2159
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
+    
+    SubClassOf: 
+        OEO_00310011,
+        <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020500
     
     
 Class: OEO_00030000


### PR DESCRIPTION
## Summary of the discussion

Based on #2159 

I didn't add the suggested axioms `participates in ...` and `has energy input ...` because of the restructuring in #2246 and #2190 and #2255.

## Type of change (CHANGELOG.md)

### Add
- biomass heat unit, oil heat unit, hydrogen heat unit, (natural) gas heat unit
- biomass heat plant, oil heat plant, hydrogen heat plant, (natural) gas heat plant

## Workflow checklist

### Automation
Closes #2159

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
