### PR TITLE
update label of nuclear electrolytic hydrogen #2235

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - add alternative label: colliery gas, lignite (#2261)
 - add alternative labels: heat generation technology, heat generation process (#2257)
 - change definition: AC-line (#2266)
+- change label: nuclear electrolytic hydrogen (#2268)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8989,7 +8989,7 @@ Class: OEO_00010416
         <http://purl.obolibrary.org/obo/IAO_0000115> "Nuclear electrolytic hydrogen is electrolytic hydrogen that is produced with nuclear electrical energy.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "pink hydrogen"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "pinker Wasserstoff"@de,
-        rdfs:label "nuclear electric hydrogen"@en,
+        rdfs:label "nuclear electrolytic hydrogen"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1490
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1559
 
@@ -8999,7 +8999,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2222
 
 remove has energy input axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2233"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2233
+
+update label
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2235
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2268"
     
     EquivalentTo: 
         OEO_00010379
@@ -11817,6 +11821,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2261"
     SubClassOf: 
         OEO_00010224,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000088
+    
+    
 Class: OEO_00020497
 
     Annotations: 


### PR DESCRIPTION
## Summary of the discussion

Based on #2235: harmonisation of labels of subclasses of `electrolytic hydrogen`

## Type of change (CHANGELOG.md)

### Update
- change label of `nuclear electrolytic hydrogen`
- 
## Workflow checklist

### Automation
Closes #2235

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
