### PR TITLE
add simulation component concept #2072

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - agricultural waste fuel, coal refuse (#2261)
 - biomass heat unit, oil heat unit, hydrogen heat unit, (natural) gas heat unit, biomass heat plant, oil heat plant, hydrogen heat plant, gas heat plant (#2262)
 - combined cycle gas power plant, open cycle gas power plant (#2263)
+- import from CCO: material artifact (#2196)
 
 ### Changed
 - change label: common reporting format / CRF sector division (#2248)
@@ -28,6 +29,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - add alternative label: colliery gas, lignite (#2261)
 - add alternative labels: heat generation technology, heat generation process (#2257)
 - change definition: AC-line (#2266)
+- change label: hardware to electronic hardware (#2196)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - biomass heat unit, oil heat unit, hydrogen heat unit, (natural) gas heat unit, biomass heat plant, oil heat plant, hydrogen heat plant, gas heat plant (#2262)
 - combined cycle gas power plant, open cycle gas power plant (#2263)
 - import from CCO: material artifact (#2196)
+- simulation component, simulation hardware component, simulation component role, device under test role, controls hardware function of (#2072)
 
 ### Changed
 - change label: common reporting format / CRF sector division (#2248)

--- a/src/ontology/edits/oeo-import-edits.owl
+++ b/src/ontology/edits/oeo-import-edits.owl
@@ -1650,6 +1650,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2016</oeo:OEO_
     
 
 
+    <!-- https://www.commoncoreontologies.org/ont00000995 -->
+
+    <owl:Class rdf:about="https://www.commoncoreontologies.org/ont00000995">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000040"/>
+    </owl:Class>
+    
+
+
     <!-- https://www.commoncoreontologies.org/ont00001141 -->
 
     <owl:Class rdf:about="https://www.commoncoreontologies.org/ont00001141">

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4588,6 +4588,56 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2125"
         OEO_00420002
     
     
+Class: OEO_00420005
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation component role is a role of an information content entity that is executable as part of a simulation and eligible to be referenced in a simulation configuration."@en,
+        rdfs:label "simulation component role"@en,
+        OEO_00020426 "added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00420006
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation component is a software that bears the simulation component role and is eligible to be referenced in a simulation configuration and executed as part of a simulation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000118> "Simulationskomponente"@de,
+        rdfs:label "simulation component"@en,
+        OEO_00020426 "added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000010>
+    
+    
+Class: OEO_00420007
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000112> "A hardware simulation component could be a software that can be integrated into a simulation and communicates with a PV inverter via a protocol to represent the current state of the PV inverter in the simulation. Additionally, this hardware simulation component could forward control messages from the simulation to the PV inverter to change parameter, e.g., a feed-in limitation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A hardware simulation component is a simulation component that represents a material artifact in a simulation process and allows to control its function."@en,
+        rdfs:label "hardware simulation component"@en,
+        OEO_00020426 "added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072"
+    
+    SubClassOf: 
+        OEO_00420006
+    
+    
+Class: OEO_00420008
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A device under test role is a role of an material artifact that is analysed within a simulation or experiment."@en,
+        rdfs:label "device under test role"@en,
+        OEO_00020426 "added:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
 Individual: <https://openenergyplatform.org/ontology/oeo/oeo-model/OEO_00400073>
 
     Annotations: 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -5444,5 +5444,4 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2006"
     
     Types: 
         OEO_00410009
-    
-    
+

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -132,6 +132,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002234>
 ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002353>
 
     
+ObjectProperty: <http://purl.obolibrary.org/obo/RO_0002410>
+
+    
 ObjectProperty: OEO_00000501
 
     
@@ -690,6 +693,25 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1945",
         OEO_00400012
     
     
+ObjectProperty: OEO_00420011
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A subrelation of causally related to between a simulation hardware component s and a material artifact m, where s is configured to manage, command, direct, or regulate m."@en,
+        rdfs:label "controls hardware function of"@en,
+        OEO_00020426 "add:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2271"@en
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/RO_0002410>
+    
+    Domain: 
+        OEO_00420007
+    
+    Range: 
+        <https://www.commoncoreontologies.org/ont00000995>
+    
+    
 ObjectProperty: owl:topObjectProperty
 
     
@@ -914,6 +936,9 @@ Class: <http://purl.obolibrary.org/obo/UO_0000036>
 
     
 Class: <http://purl.obolibrary.org/obo/UO_0000046>
+
+    
+Class: <https://www.commoncoreontologies.org/ont00000995>
 
     
 Class: OEO_00000048

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4594,7 +4594,8 @@ Class: OEO_00420005
         <http://purl.obolibrary.org/obo/IAO_0000115> "A simulation component role is a role of an information content entity that is executable as part of a simulation and eligible to be referenced in a simulation configuration."@en,
         rdfs:label "simulation component role"@en,
         OEO_00020426 "added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2271"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>
@@ -4607,7 +4608,8 @@ Class: OEO_00420006
         <http://purl.obolibrary.org/obo/IAO_0000118> "Simulationskomponente"@de,
         rdfs:label "simulation component"@en,
         OEO_00020426 "added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2271"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000010>
@@ -4620,7 +4622,8 @@ Class: OEO_00420007
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hardware simulation component is a simulation component that represents a material artifact in a simulation process and allows to control its function."@en,
         rdfs:label "hardware simulation component"@en,
         OEO_00020426 "added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2271"
     
     SubClassOf: 
         OEO_00420006
@@ -4632,7 +4635,8 @@ Class: OEO_00420008
         <http://purl.obolibrary.org/obo/IAO_0000115> "A device under test role is a role of an material artifact that is analysed within a simulation or experiment."@en,
         rdfs:label "device under test role"@en,
         OEO_00020426 "added:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072"
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2072
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2271"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000023>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -4643,7 +4643,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2271"
 Class: OEO_00420007
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000112> "A hardware simulation component could be a software that can be integrated into a simulation and communicates with a PV inverter via a protocol to represent the current state of the PV inverter in the simulation. Additionally, this hardware simulation component could forward control messages from the simulation to the PV inverter to change parameter, e.g., a feed-in limitation."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000112> "A hardware simulation component could be a software that can be integrated into a simulation and is able to communicate with, e.g., a PV inverter via a protocol to represent the current state of the PV inverter in the simulation. Additionally, this hardware simulation component forwards control messages from the simulation to the PV inverter to change parameter, e.g., a feed-in limitation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000115> "A hardware simulation component is a simulation component that represents a material artifact in a simulation process and allows to control its function."@en,
         rdfs:label "hardware simulation component"@en,
         OEO_00020426 "added:

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -3250,8 +3250,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/752"
 Class: OEO_00000206
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "Hardware is an artificial object that is part of an electronic system.",
-        rdfs:label "hardware"@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "Electronic hardware is an artificial object that is part of an electronic system.",
+        rdfs:label "electronic hardware"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/319
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/350
 
@@ -3264,7 +3264,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 remove has energy output axiom 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2233"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2233
+
+rename to electronic hardware
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2196
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2267"
     
     SubClassOf: 
         OEO_00000061

--- a/src/ontology/imports/cco-extracted.owl
+++ b/src/ontology/imports/cco-extracted.owl
@@ -3246,6 +3246,41 @@
     
 
 
+    <!-- https://www.commoncoreontologies.org/ont00000995 -->
+
+    <owl:Class rdf:about="https://www.commoncoreontologies.org/ont00000995">
+        <rdfs:isDefinedBy rdf:resource="https://openenergyplatform.org/ontology/oeo/imports/cco-extracted.owl"/>
+        <rdfs:label xml:lang="en">Material Artifact</rdfs:label>
+        <skos:definition xml:lang="en">A Material Entity that was designed by some Agent to realize a certain Function.</skos:definition>
+        <www:ont00001760 rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://www.commoncoreontologies.org/ArtifactOntology</www:ont00001760>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://www.commoncoreontologies.org/ont00000995"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="https://openenergyplatform.org/ontology/oeo/dev/imports/cco-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://www.commoncoreontologies.org/ont00000995"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget xml:lang="en">Material Artifact</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="https://openenergyplatform.org/ontology/oeo/dev/imports/cco-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://www.commoncoreontologies.org/ont00000995"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2004/02/skos/core#definition"/>
+        <owl:annotatedTarget xml:lang="en">A Material Entity that was designed by some Agent to realize a certain Function.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="https://openenergyplatform.org/ontology/oeo/dev/imports/cco-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://www.commoncoreontologies.org/ont00000995"/>
+        <owl:annotatedProperty rdf:resource="https://www.commoncoreontologies.org/ont00001760"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://www.commoncoreontologies.org/ArtifactOntology</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="https://openenergyplatform.org/ontology/oeo/dev/imports/cco-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
     <!-- https://www.commoncoreontologies.org/ont00000999 -->
 
     <owl:Class rdf:about="https://www.commoncoreontologies.org/ont00000999">


### PR DESCRIPTION
## Summary of the discussion

Closes: #2072 


## Type of change (CHANGELOG.md)

### Add
- Add classes: `simulation component`, `simulation hardware component`, `simulation components role`, and `device under test role` [#2072](https://github.com/OpenEnergyPlatform/ontology/issues/2072)
- Add object property: `controls hardware function of` [#2072](https://github.com/OpenEnergyPlatform/ontology/issues/2072)

### Update
- 

### Remove
- 

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
