### PR TITLE
2282 ontology files are not easily findable

### DIFF
--- a/.github/workflows/PostReleaseScripts.yml
+++ b/.github/workflows/PostReleaseScripts.yml
@@ -127,7 +127,7 @@ jobs:
           cd ../../../..
       - name: Copy built ontology files to workspace
         run: |
-          find build/oeo/ -maxdepth 2 -name "oeo-full.*" -exec cp {} ${{ github.workspace }} \;
+          find build/oeo/ -maxdepth 2 -name "oeo-full.*" -o -name "oeo-closure.*" -exec cp {} ${{ github.workspace }} \;
       - name: Attach artifacts to release
         uses: ncipollo/release-action@v1
         with:
@@ -144,4 +144,4 @@ jobs:
           # We don't want this behaviour, as releases created as draft or pre-release won't be updated in that regard and therefore result in
           # unconsistent behaviour when creating normal releases vs. draft or pre-releases.
           makeLatest: false
-          artifacts: "${{ github.workspace }}/build-files.zip,${{ github.workspace }}/existing-terms-and-definitions.zip,${{ github.workspace }}/oeo-full.omn,${{ github.workspace }}/oeo-full.owl"
+          artifacts: "${{ github.workspace }}/build-files.zip,${{ github.workspace }}/existing-terms-and-definitions.zip,${{ github.workspace }}/oeo-full.omn,${{ github.workspace }}/oeo-full.owl,${{ github.workspace }}/oeo-closure.owl"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ This domain ontology is a collaborative effort to represent the context of **ene
 This repository is **dual-licensed** under [Creative Commons Zero v1.0 Universal (CC0-1.0)](https://creativecommons.org/publicdomain/zero/1.0/legalcode) or [MIT License (MIT)](https://opensource.org/license/mit). <br>
 You can choose between one of them if you use this work. <br>
 
+## Download
+
+Download the latest released version from the release page or here:
+
+- [oeo-full.owl](https://github.com/OpenEnergyPlatform/ontology/releases/latest/download/oeo-full.owl)
+- [oeo-closure.owl](https://github.com/OpenEnergyPlatform/ontology/releases/latest/download/oeo-closure.owl)
+
+
 ## Citation
 
 For **scientific citation** of this ontology, please refer to the [CITATION.cff](CITATION.cff) file. <br>
@@ -45,8 +53,8 @@ Example:
 ## Releases and installation
 
 With every release, two versions of OEO are published:
-- oeo-full.owl which contains the asserted hierarchy
-- oeo-closure.owl which contains the inferred hierarchy by the HermiT reasoner
+- [oeo-full.owl](https://github.com/OpenEnergyPlatform/ontology/releases/latest/download/oeo-full.owl) which contains the asserted hierarchy
+- [oeo-closure.owl](https://github.com/OpenEnergyPlatform/ontology/releases/latest/download/oeo-closure.owl) which contains the inferred hierarchy by the HermiT reasoner
 
 All released versions can be downloaded directly from the [GitHub Releases](https://github.com/OpenEnergyPlatform/ontology/releases/). <br>
 The latest version of the OEO can also be accessed on the [Open Energy Platform](https://openenergyplatform.org/ontology/oeo) and the [Master Branch](https://github.com/OpenEnergyPlatform/ontology/tree/master). <br>


### PR DESCRIPTION
## Summary of the discussion

- Add links to oeo-full.owl and oeo-closure.owl to the README
- Add automation to attach oeo-closure.owl as a single file to the release artifacts.

## Type of change (CHANGELOG.md)

### Add


### Update


### Remove


## Workflow checklist

### Automation
Closes #2282 

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
