### PR TITLE
harmonize oekg annotations in oeo-social to study descriptor tag #2295

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 ### Added
 - CSV, JSON, CPACS, KML, BADA, VTK, NetCDF, SO6, GeoTiff (#2251)
 ### Changed
+- Updated oekg annotation: decarbonisation pathway, sufficiency, policy instrument, acceptance (#2296)
+- Updated oekg annotation: study report due to legal obligation, model coupling, regionalisation, model intercomparison study, scenario projection comparison (#2296)
+- Updated oekg annotation: electricity grid, greenhouse gas emission, negative emission, gas grid, heating grid, electrical energy share, sector coupling, energy conversion efficiency, renewable energy share, gross electricity generation, CO2 emission, flexibility, resilience, life cycle assessment (#2296)
 ### Removed
 
 ## [2.13.0] - 2026-07-10

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -14,7 +14,7 @@
     <uri id="Imports Wizard Entry" name="https://openenergyplatform.org/ontology/oeo/dev/imports/cco-extracted.owl" uri="../imports/cco-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="https://openenergyplatform.org/ontology/oeo/dev/imports/meno-extracted.owl" uri="../imports/meno-extracted.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1776758144454" name="https://openenergyplatform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1776758144454" name="https://openenergyplatform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1784859899111" name="https://openenergyplatform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1784859899111" name="https://openenergyplatform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2989,7 +2989,7 @@ Class: OEO_00020373
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study report due to legal obligation is a study report that is created beacause of a legal obligation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "legally mandatory study report"@en,
         rdfs:label "study report due to legal obligation"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1641
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1777
 add oekg annotation
@@ -3005,7 +3005,7 @@ Class: OEO_00020406
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Model coupling is a model calculation in which output data from one or more numerical computer models is used as input data for one or more other models.",
         rdfs:label "model coupling",
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1521
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1842
 add oekg annotation
@@ -3713,7 +3713,7 @@ Class: OEO_00340006
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Regionalisation is a methodology to calculate spatially distributed energy producers and consumers with the aim to highlight regional differences in energy supply and potentials, particularly related to renewable energies.",
         rdfs:label "regionalisation"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1554
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1639
 
@@ -3734,7 +3734,7 @@ Class: OEO_00360002
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model intercomparison study is a scenario study that performs a comparison of several models using a reference scenario."@en,
         rdfs:label "model intercomparison study"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1640
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1711
 add oekg annotation
@@ -3750,7 +3750,7 @@ Class: OEO_00360003
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario comparison study is a scenario study that performs a scenario projection comparison"@en,
         rdfs:label "scenario projection comparison"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1640
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1711
 add oekg annotation
@@ -3988,7 +3988,7 @@ Class: OEO_00390064
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study descriptor is a data descriptor that allows the annotation of study information within a scenario bundle by means of keywords from ontological terminology.",
-        rdfs:label "study descriptor"@en,
+        rdfs:label "study descriptor tag"@en,
         OEO_00020426 "add:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1943
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1950"

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2989,7 +2989,7 @@ Class: OEO_00020373
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study report due to legal obligation is a study report that is created beacause of a legal obligation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "legally mandatory study report"@en,
         rdfs:label "study report due to legal obligation"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1641
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1777
 add oekg annotation
@@ -3008,7 +3008,7 @@ Class: OEO_00020406
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Model coupling is a model calculation in which output data from one or more numerical computer models is used as input data for one or more other models.",
         rdfs:label "model coupling",
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1521
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1842
 add oekg annotation
@@ -3719,7 +3719,7 @@ Class: OEO_00340006
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Regionalisation is a methodology to calculate spatially distributed energy producers and consumers with the aim to highlight regional differences in energy supply and potentials, particularly related to renewable energies.",
         rdfs:label "regionalisation"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1554
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1639
 
@@ -3744,7 +3744,7 @@ Class: OEO_00360002
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model intercomparison study is a scenario study that performs a comparison of several models using a reference scenario."@en,
         rdfs:label "model intercomparison study"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1640
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1711
 add oekg annotation
@@ -3763,7 +3763,7 @@ Class: OEO_00360003
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario comparison study is a scenario study that performs a scenario projection comparison"@en,
         rdfs:label "scenario projection comparison"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1640
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1711
 add oekg annotation

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -2989,12 +2989,15 @@ Class: OEO_00020373
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study report due to legal obligation is a study report that is created beacause of a legal obligation."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "legally mandatory study report"@en,
         rdfs:label "study report due to legal obligation"@en,
-        OEO_00020425 "study descriptor tag",
+        OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1641
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1777
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00020012
@@ -3005,12 +3008,15 @@ Class: OEO_00020406
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Model coupling is a model calculation in which output data from one or more numerical computer models is used as input data for one or more other models.",
         rdfs:label "model coupling",
-        OEO_00020425 "study descriptor tag",
+        OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1521
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1842
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00000275
@@ -3713,7 +3719,7 @@ Class: OEO_00340006
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Regionalisation is a methodology to calculate spatially distributed energy producers and consumers with the aim to highlight regional differences in energy supply and potentials, particularly related to renewable energies.",
         rdfs:label "regionalisation"@en,
-        OEO_00020425 "study descriptor tag",
+        OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1554
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1639
 
@@ -3723,7 +3729,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1899
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00020166
@@ -3734,12 +3744,15 @@ Class: OEO_00360002
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A model intercomparison study is a scenario study that performs a comparison of several models using a reference scenario."@en,
         rdfs:label "model intercomparison study"@en,
-        OEO_00020425 "study descriptor tag",
+        OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1640
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1711
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00010252
@@ -3750,12 +3763,15 @@ Class: OEO_00360003
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A scenario comparison study is a scenario study that performs a scenario projection comparison"@en,
         rdfs:label "scenario projection comparison"@en,
-        OEO_00020425 "study descriptor tag",
+        OEO_00020425 "study descriptor",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1640
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1711
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00010252
@@ -3988,7 +4004,7 @@ Class: OEO_00390064
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study descriptor is a data descriptor that allows the annotation of study information within a scenario bundle by means of keywords from ontological terminology.",
-        rdfs:label "study descriptor tag"@en,
+        rdfs:label "study descriptor"@en,
         OEO_00020426 "add:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1943
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1950"

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -3988,7 +3988,7 @@ Class: OEO_00390064
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A study descriptor is a data descriptor that allows the annotation of study information within a scenario bundle by means of keywords from ontological terminology.",
-        rdfs:label "study descriptor tag"@en,
+        rdfs:label "study descriptor"@en,
         OEO_00020426 "add:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1943
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1950"

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2615,7 +2615,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2073
 
 Added 'part of' some 'power system' axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1960
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2042"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2042
+
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00000200,
@@ -3186,7 +3190,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
 
 add subclassof axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2138
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2143"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2143
+
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     EquivalentTo: 
         OEO_00000147
@@ -3867,7 +3875,10 @@ Class: OEO_00000293
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -9859,7 +9870,10 @@ Class: OEO_00020004
 pull request: https://github.com/OpenEnergyPlatform/ontology/385
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00000200,
@@ -9877,7 +9891,9 @@ Class: OEO_00020005
 pull request: https://github.com/OpenEnergyPlatform/ontology/385
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00000200,
@@ -11076,7 +11092,10 @@ Class: OEO_00020254
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00030019,
@@ -11493,7 +11512,10 @@ Class: OEO_00020408
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1842
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
@@ -13117,7 +13139,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00030019,
@@ -13751,7 +13776,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00030019,
@@ -14261,7 +14289,10 @@ Class: OEO_00240012
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00030019,
@@ -14686,7 +14717,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"@en
     
     EquivalentTo: 
         OEO_00000147
@@ -17000,10 +17034,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
-
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,
@@ -17106,10 +17142,12 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1744
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
-
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000016>,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -13847,6 +13847,9 @@ add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
     
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     SubClassOf: 
         OEO_00140040
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -2588,7 +2588,7 @@ Class: OEO_00000143
         <http://purl.obolibrary.org/obo/IAO_0000115> "An electricity grid is a supply grid that transfers electrical energy / electricity."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Stromnetz"@de,
         rdfs:label "electricity grid"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/138
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/165
 
@@ -3162,7 +3162,7 @@ Class: OEO_00000199
         <http://purl.obolibrary.org/obo/IAO_0000115> "A greenhouse gas emission is an emission that releases a greenhouse gas.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Treibhausgasemission"@de,
         rdfs:label "greenhouse gas emission"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/406
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/410
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
@@ -3862,7 +3862,7 @@ Class: OEO_00000293
         <http://purl.obolibrary.org/obo/IAO_0000115> "Negative emission is the process of absorbing a substance, usually a pollutant that was emitted before.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "negative Emission"@de,
         rdfs:label "negative emission"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/56
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/234
 add oekg annotation
@@ -9854,7 +9854,7 @@ Class: OEO_00020004
         <http://purl.obolibrary.org/obo/IAO_0000115> "A gas grid is a supply grid that distributes gaseous fuel, e.g. methane.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Gasnetz"@de,
         rdfs:label "gas grid"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385
 add oekg annotation
@@ -9872,7 +9872,7 @@ Class: OEO_00020005
         <http://purl.obolibrary.org/obo/IAO_0000115> "A heating grid is a supply grid that distributes thermal energy via circulating steam or liquids."@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wärmenetz"@de,
         rdfs:label "heating grid"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/36
 pull request: https://github.com/OpenEnergyPlatform/ontology/385
 add oekg annotation
@@ -11071,7 +11071,7 @@ Class: OEO_00020254
         <http://purl.obolibrary.org/obo/IAO_0000115> "Electrical energy share is a process attribute that indicates the fraction of electrical energy related to the total energy of an energy generation or consumption process.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "degree of electrification",
         rdfs:label "electrical energy share"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1561
 add oekg annotation
@@ -11488,7 +11488,7 @@ Class: OEO_00020408
         <http://purl.obolibrary.org/obo/IAO_0000115> "Sector coupling is a process of connecting processes from the electricity, heat, mobility or industrial sectors as well as their infrastructures.",
         <http://purl.obolibrary.org/obo/IAO_0000600> "The aim of sector coupling is usually an optimisation of an energy system (e.g. with respect to cost, environmental impact, sustainability and decarbonisation) by establishing energy flows across sectorial borders",
         rdfs:label "sector coupling",
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1521
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1842
 add oekg annotation
@@ -13105,7 +13105,7 @@ Class: OEO_00140049
         <http://purl.obolibrary.org/obo/IAO_0000118> "Energieumwandlungseffizienz"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wirkungsgrad"@de,
         rdfs:label "energy conversion efficiency"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/434
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/591
 
@@ -13743,7 +13743,7 @@ Class: OEO_00140133
         <http://purl.obolibrary.org/obo/IAO_0000118> "erneuerbarer Anteil"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "renewables share"@en,
         rdfs:label "renewable energy share"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/187
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/780
 axiom to RE share value and alternative label
@@ -13807,7 +13807,7 @@ Class: OEO_00140146
         <http://purl.obolibrary.org/obo/IAO_0000118> "Energiebedarf"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Energienachfrage"@de,
         rdfs:label "energy demand"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/794
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/796
 
@@ -14256,7 +14256,7 @@ Class: OEO_00240012
         <http://purl.obolibrary.org/obo/IAO_0000118> "Bruttostromerzeugung"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "gross electricity production"@en,
         rdfs:label "gross electricity generation"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/917
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/932
 add oekg annotation
@@ -14674,7 +14674,7 @@ Class: OEO_00260007
         <http://purl.obolibrary.org/obo/IAO_0000118> "CO2-Emission"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "carbon dioxide emission"@en,
         rdfs:label "CO2 emission"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/866
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1253/
 
@@ -16994,7 +16994,7 @@ Class: OEO_00360007
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Flexibility is a disposition of an energy system that is able to balance energy by adjusting energy supply and energy demand."@en,
         rdfs:label "flexibility"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1549
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1717
 add oekg annotation
@@ -17100,7 +17100,7 @@ Class: OEO_00360015
         <http://purl.obolibrary.org/obo/IAO_0000115> "Resilience is a disposition of a system that represents the capacity of a system to absorb disturbance and reorganize so as to retain essentially the same function, structure, and feedbacks."@en,
         <http://purl.obolibrary.org/obo/IAO_0000119> "B. Walker, C. S. Holling, S. R. Carpenter, and A. Kinzig, “Resilience, adaptability and transformability in social–ecological systems,” Ecol. Soc., vol. 9, no. 2, 2004, Art. no. 5",
         rdfs:label "resilience"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1550
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1744
 add oekg annotation

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -13845,7 +13845,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
     
 update oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9891,7 +9891,8 @@ Class: OEO_00020005
 pull request: https://github.com/OpenEnergyPlatform/ontology/385
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897update oekg annotation
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2208,7 +2208,7 @@ Class: OEO_00330023
         <http://purl.obolibrary.org/obo/IAO_0000118> "life cycle analysis"@en,
         <http://purl.obolibrary.org/obo/IAO_0000118> "Ökobilanz"@de,
         rdfs:label "life cycle assessment"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1551
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576
 add oekg annotation

--- a/src/ontology/edits/oeo-shared.omn
+++ b/src/ontology/edits/oeo-shared.omn
@@ -2213,7 +2213,10 @@ Class: OEO_00330023
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1576
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00020166

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -685,7 +685,10 @@ Class: OEO_00010212
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         OEO_00140150
@@ -826,7 +829,10 @@ Jonas Lage, Johannes Thema, Carina Zell-Ziegler, Benjamin Best, Luisa Cordroch, 
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1648
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000104>
@@ -2477,7 +2483,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1791
 
 add oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
+
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/IAO_0000007>,
@@ -2754,7 +2764,10 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1529
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
 replaced 'has bearer' with 'characteristic of'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1907
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928"@en
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1928
+update oekg annotation
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"@en
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000017>,

--- a/src/ontology/edits/oeo-social.omn
+++ b/src/ontology/edits/oeo-social.omn
@@ -680,7 +680,7 @@ Class: OEO_00010212
         <http://purl.obolibrary.org/obo/IAO_0000115> "A decarbonisation pathway is a policy that aims at long-term emissions reductions.",
         <http://purl.obolibrary.org/obo/IAO_0000118> "Dekarbonisierungspfad"@de,
         rdfs:label "decarbonisation pathway"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/831
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/951
 add oekg annotation
@@ -821,7 +821,7 @@ Class: OEO_00010444
 Jonas Lage, Johannes Thema, Carina Zell-Ziegler, Benjamin Best, Luisa Cordroch, and Frauke Wiese (2023): Citizens call for sufficiency and regulation — A comparison of European citizen assemblies and National Energy and Climate Plans. In: Energy Research & Social Science, Vol. 104, https://doi.org/10.1016/j.erss.2023.103254",
         <http://purl.obolibrary.org/obo/IAO_0000600> "This definition consists of three characteristics that are present in most definitions of sufficiency: 1) sufficiency is understood as a strategy for achieving mainly (but not solely) environmental goals of sustainability, 2) sufficiency pursues sustainability goals by absolute reductions in consumption and production and 3) sufficiency implies a focus on social innovation to change social practices and individual behaviour.",
         rdfs:label "sufficiency"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1553
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1648
 add oekg annotation
@@ -2451,7 +2451,7 @@ Class: OEO_00140151
         <http://purl.obolibrary.org/obo/IAO_0000118> "Politikinstrument"@de,
         <http://purl.obolibrary.org/obo/IAO_0000118> "policies and measures"@en,
         rdfs:label "policy instrument"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/444
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/797
 
@@ -2746,7 +2746,7 @@ Class: OEO_00360000
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "Acceptance is a realizable entity that represents the attitude of a person or organisation with respect to a certain constructional, (infra)structural or political measure that may be realized in, affected by or results of complex processes like discussions, communications, transformative measures or former personal experiences."@en,
         rdfs:label "acceptance"@en,
-        OEO_00020425 "study descriptor",
+        OEO_00020425 "study descriptor tag",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1552
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1698
 add oekg annotation


### PR DESCRIPTION
## Summary of the discussion

Based on #2295: 
There are two different `oekg annotation` values for study descriptors: "study descriptor" and "study descriptor tag". They are harmonized, i.e. all are given the value "study descriptor tag". 

## Type of change (CHANGELOG.md)

### Update
- Updated oekg annotation: decarbonisation pathway, sufficiency, policy instrument, acceptance
- Updated oekg annotation: study report due to legal obligation, model coupling, regionalisation, model intercomparison study, scenario projection comparison
- Updated oekg annotation: electricity grid, greenhouse gas emission, negative emission, gas grid, heating grid, electrical energy share, sector coupling, energy conversion efficiency, renewable energy share, gross electricity generation, CO2 emission, flexibility, resilience, life cycle assessment

## Workflow checklist

### Automation
Closes #2295

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
