### PR TITLE
deprecate `has / is energy participant` relations #2190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - Updated oekg annotation: study report due to legal obligation, model coupling, regionalisation, model intercomparison study, scenario projection comparison (#2296)
 - Updated oekg annotation: electricity grid, greenhouse gas emission, negative emission, gas grid, heating grid, electrical energy share, sector coupling, energy conversion efficiency, renewable energy share, gross electricity generation, CO2 emission, flexibility, resilience, life cycle assessment (#2296)
 
-### Removed
+### Removed / Deprecated
+- has energy participant and subrelations, is energy participant of and subrelations (#2303)
 
 ## [2.13.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - Updated oekg annotation: study report due to legal obligation, model coupling, regionalisation, model intercomparison study, scenario projection comparison (#2296)
 - Updated oekg annotation: electricity grid, greenhouse gas emission, negative emission, gas grid, heating grid, electrical energy share, sector coupling, energy conversion efficiency, renewable energy share, gross electricity generation, CO2 emission, flexibility, resilience, life cycle assessment (#2296)
 
-### Removed / Deprecated
+### Removed / Obsolete
 - has energy participant and subrelations, is energy participant of and subrelations (#2303)
 
 ## [2.13.0] - 2026-07-10

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -75,9 +75,6 @@ AnnotationProperty: dc:contributor
 AnnotationProperty: dc:description
 
     
-AnnotationProperty: owl:deprecated
-
-    
 AnnotationProperty: rdfs:comment
 
     
@@ -85,9 +82,6 @@ AnnotationProperty: rdfs:isDefinedBy
 
     
 AnnotationProperty: rdfs:label
-
-    
-AnnotationProperty: rdfs:seeAlso
 
     
 AnnotationProperty: skos:altLabel
@@ -106,9 +100,6 @@ AnnotationProperty: skos:relatedMatch
 
     
 Datatype: rdf:PlainLiteral
-
-    
-Datatype: xsd:boolean
 
     
 Datatype: xsd:decimal
@@ -524,11 +515,27 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
 ObjectProperty: OEO_00010235
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED has energy output"@en,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
+        rdfs:label "has energy output"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+    
+    SubPropertyOf: 
+        <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00010473
@@ -629,21 +636,37 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
 ObjectProperty: OEO_00020259
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED has main energy output"@en,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is the intended energy output of p, e.g. for further usage.",
+        rdfs:label "has main energy output"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
+    
+    SubPropertyOf: 
+        OEO_00010235
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00020260
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED has waste energy output"@en,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is an unintended, unwanted or unevitable output of p, e.g. waste heat.",
+        rdfs:label "has waste energy output"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
+    
+    SubPropertyOf: 
+        OEO_00010235
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00020404
@@ -705,10 +728,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270"
 ObjectProperty: OEO_00020506
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a material entity m and an energy e, where m possesses a disposition d to consume / decrease energy which is realized in a process p, which has an energy decrease process as occurent part which negatively regulates energy e and which occurs in m.",
         rdfs:label "consumes energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2246
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270",
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a material entity m and an energy e, where m possesses a disposition d to consume / decrease energy which is realized in a process p, which has an energy decrease process as occurent part which negatively regulates energy e and which occurs in m."
     
     SubPropertyOf: 
         OEO_00020505
@@ -762,21 +785,45 @@ ObjectProperty: OEO_00140164
 ObjectProperty: OEO_00140175
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED has gross output"@en,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has gross output c iff: p has energy output c, and c is the total amount of energy generated during the process.",
+        rdfs:label "has gross output"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
+
+make subproperty of 'has energy output' and add domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
+    
+    SubPropertyOf: 
+        OEO_00010235
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00140176
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED has net output"@en,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "p has net output c iff: p has energy output c, and c is the amount of energy delivered to the consumer or fed into a supply grid.",
+        rdfs:label "has net output"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
+
+make subproperty of 'has energy output' and add domain:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
+    
+    SubPropertyOf: 
+        OEO_00010235
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00240025
@@ -11973,6 +12020,34 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
         OEO_00310011,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020500
     
+ 
+Class: OEO_00020514
+
+    Annotations: 
+        rdfs:comment "A base load power plant role is a role of a powerplant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. Usually coal power plants and nuclear power plants bear that role.",
+        rdfs:label "base load power plant role"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00020515
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A base load power plant is a power plant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. It possesses the base load power plant role.",
+        rdfs:label "base load power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
+
+    EquivalentTo: 
+        OEO_00000031
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020514)
+    
+    SubClassOf: 
+        OEO_00000031
+        
     
 Class: OEO_00020508
 
@@ -12000,8 +12075,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270"
         <http://purl.obolibrary.org/obo/BFO_0000016>,
         <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003,
         <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
-    
-    
+
 Class: OEO_00020512
 
     Annotations: 
@@ -12031,36 +12105,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2277"
     SubClassOf: 
         OEO_00000220,
         OEO_00000530 some OEO_00030005
-    
-    
-Class: OEO_00020514
-
-    Annotations: 
-        rdfs:comment "A base load power plant role is a role of a powerplant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. Usually coal power plants and nuclear power plants bear that role.",
-        rdfs:label "base load power plant role"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: OEO_00020515
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A base load power plant is a power plant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. It possesses the base load power plant role.",
-        rdfs:label "base load power plant"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
-    
-    EquivalentTo: 
-        OEO_00000031
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020514)
-    
-    SubClassOf: 
-        OEO_00000031
-    
-    
+        
+        
 Class: OEO_00020516
 
     Annotations: 
@@ -12072,6 +12118,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2297"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
+
     
     
 Class: OEO_00030000
@@ -13970,7 +14017,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
 update oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
-    
     SubClassOf: 
         OEO_00140040
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -75,6 +75,9 @@ AnnotationProperty: dc:contributor
 AnnotationProperty: dc:description
 
     
+AnnotationProperty: owl:deprecated
+
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -82,6 +85,9 @@ AnnotationProperty: rdfs:isDefinedBy
 
     
 AnnotationProperty: rdfs:label
+
+    
+AnnotationProperty: rdfs:seeAlso
 
     
 AnnotationProperty: skos:altLabel
@@ -100,6 +106,9 @@ AnnotationProperty: skos:relatedMatch
 
     
 Datatype: rdf:PlainLiteral
+
+    
+Datatype: xsd:boolean
 
     
 Datatype: xsd:decimal
@@ -515,27 +524,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
 ObjectProperty: OEO_00010235
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
-        rdfs:label "has energy output"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
-    
-    SubPropertyOf: 
-        <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
-    
-    Range: 
-        OEO_00000150
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED has energy output"@en,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
+        owl:deprecated true
     
     
 ObjectProperty: OEO_00010473
@@ -636,37 +629,21 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
 ObjectProperty: OEO_00020259
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is the intended energy output of p, e.g. for further usage.",
-        rdfs:label "has main energy output"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
-    
-    SubPropertyOf: 
-        OEO_00010235
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED has main energy output"@en,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
+        owl:deprecated true
     
     
 ObjectProperty: OEO_00020260
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is an unintended, unwanted or unevitable output of p, e.g. waste heat.",
-        rdfs:label "has waste energy output"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
-    
-    SubPropertyOf: 
-        OEO_00010235
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED has waste energy output"@en,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
+        owl:deprecated true
     
     
 ObjectProperty: OEO_00020404
@@ -728,10 +705,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270"
 ObjectProperty: OEO_00020506
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a material entity m and an energy e, where m possesses a disposition d to consume / decrease energy which is realized in a process p, which has an energy decrease process as occurent part which negatively regulates energy e and which occurs in m.",
         rdfs:label "consumes energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2246
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a material entity m and an energy e, where m possesses a disposition d to consume / decrease energy which is realized in a process p, which has an energy decrease process as occurent part which negatively regulates energy e and which occurs in m."
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270"
     
     SubPropertyOf: 
         OEO_00020505
@@ -785,45 +762,21 @@ ObjectProperty: OEO_00140164
 ObjectProperty: OEO_00140175
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has gross output c iff: p has energy output c, and c is the total amount of energy generated during the process.",
-        rdfs:label "has gross output"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
-
-make subproperty of 'has energy output' and add domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
-    
-    SubPropertyOf: 
-        OEO_00010235
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
-    
-    Range: 
-        OEO_00000150
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED has gross output"@en,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
+        owl:deprecated true
     
     
 ObjectProperty: OEO_00140176
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "p has net output c iff: p has energy output c, and c is the amount of energy delivered to the consumer or fed into a supply grid.",
-        rdfs:label "has net output"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
-
-make subproperty of 'has energy output' and add domain:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
-    
-    SubPropertyOf: 
-        OEO_00010235
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
-    
-    Range: 
-        OEO_00000150
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED has net output"@en,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
+        owl:deprecated true
     
     
 ObjectProperty: OEO_00240025
@@ -12020,34 +11973,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
         OEO_00310011,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020500
     
- 
-Class: OEO_00020514
-
-    Annotations: 
-        rdfs:comment "A base load power plant role is a role of a powerplant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. Usually coal power plants and nuclear power plants bear that role.",
-        rdfs:label "base load power plant role"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: OEO_00020515
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A base load power plant is a power plant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. It possesses the base load power plant role.",
-        rdfs:label "base load power plant"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
-
-    EquivalentTo: 
-        OEO_00000031
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020514)
-    
-    SubClassOf: 
-        OEO_00000031
-        
     
 Class: OEO_00020508
 
@@ -12075,7 +12000,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270"
         <http://purl.obolibrary.org/obo/BFO_0000016>,
         <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003,
         <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
-
+    
+    
 Class: OEO_00020512
 
     Annotations: 
@@ -12105,8 +12031,36 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2277"
     SubClassOf: 
         OEO_00000220,
         OEO_00000530 some OEO_00030005
-        
-        
+    
+    
+Class: OEO_00020514
+
+    Annotations: 
+        rdfs:comment "A base load power plant role is a role of a powerplant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. Usually coal power plants and nuclear power plants bear that role.",
+        rdfs:label "base load power plant role"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00020515
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A base load power plant is a power plant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. It possesses the base load power plant role.",
+        rdfs:label "base load power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
+    
+    EquivalentTo: 
+        OEO_00000031
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020514)
+    
+    SubClassOf: 
+        OEO_00000031
+    
+    
 Class: OEO_00020516
 
     Annotations: 
@@ -12118,7 +12072,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2297"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
-
     
     
 Class: OEO_00030000
@@ -14017,6 +13970,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
 update oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
+    
     SubClassOf: 
         OEO_00140040
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -87,6 +87,9 @@ AnnotationProperty: rdfs:isDefinedBy
 AnnotationProperty: rdfs:label
 
     
+AnnotationProperty: rdfs:seeAlso
+
+    
 AnnotationProperty: skos:altLabel
 
     
@@ -201,6 +204,7 @@ ObjectProperty: <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is used in the artificial object or process.",
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
         rdfs:label "has energy participant"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
@@ -211,7 +215,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     Domain: 
         <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
@@ -499,7 +507,10 @@ ObjectProperty: OEO_00010234
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
         rdfs:label "has energy input"@en,
+        rdfs:seeAlso "OEO_00020506 (consumes energy)
+OEO_00020462 (decreases energy)",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
@@ -509,7 +520,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     SubPropertyOf: 
         <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
@@ -522,7 +537,10 @@ ObjectProperty: OEO_00010235
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
         rdfs:label "has energy output"@en,
+        rdfs:seeAlso "OEO_00020507 (produces energy)
+OEO_00020461 (increases energy)",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
@@ -532,7 +550,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     SubPropertyOf: 
         <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
@@ -624,9 +646,16 @@ ObjectProperty: OEO_00020257
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as major energy input for p.",
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
         rdfs:label "has main energy input"@en,
+        rdfs:seeAlso "OEO_00020506 (consumes energy)
+OEO_00020462 (decreases energy)",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
+
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     SubPropertyOf: 
         OEO_00010234
@@ -642,9 +671,16 @@ ObjectProperty: OEO_00020258
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as input for p, but not as main input.",
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
         rdfs:label "has auxilary energy input"@en,
+        rdfs:seeAlso "OEO_00020506 (consumes energy)
+OEO_00020462 (decreases energy)",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
+
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     SubPropertyOf: 
         OEO_00010234
@@ -660,9 +696,16 @@ ObjectProperty: OEO_00020259
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is the intended energy output of p, e.g. for further usage.",
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
         rdfs:label "has main energy output"@en,
+        rdfs:seeAlso "OEO_00020507 (produces energy)
+OEO_00020461 (increases energy)",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
+
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     SubPropertyOf: 
         OEO_00010235
@@ -678,9 +721,16 @@ ObjectProperty: OEO_00020260
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is an unintended, unwanted or unevitable output of p, e.g. waste heat.",
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
         rdfs:label "has waste energy output"@en,
+        rdfs:seeAlso "OEO_00020507 (produces energy)
+OEO_00020461 (increases energy)",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
+
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     SubPropertyOf: 
         OEO_00010235
@@ -809,13 +859,20 @@ ObjectProperty: OEO_00140175
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "p has gross output c iff: p has energy output c, and c is the total amount of energy generated during the process.",
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
         rdfs:label "has gross output"@en,
+        rdfs:seeAlso "OEO_00020507 (produces energy)
+OEO_00020461 (increases energy)",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
 
 make subproperty of 'has energy output' and add domain:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     SubPropertyOf: 
         OEO_00010235
@@ -831,13 +888,20 @@ ObjectProperty: OEO_00140176
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "p has net output c iff: p has energy output c, and c is the amount of energy delivered to the consumer or fed into a supply grid.",
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
         rdfs:label "has net output"@en,
+        rdfs:seeAlso "OEO_00020507 (produces energy)
+OEO_00020461 (increases energy)",
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
 
 make subproperty of 'has energy output' and add domain:
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     SubPropertyOf: 
         OEO_00010235

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -75,6 +75,9 @@ AnnotationProperty: dc:contributor
 AnnotationProperty: dc:description
 
     
+AnnotationProperty: owl:deprecated
+
+    
 AnnotationProperty: rdfs:comment
 
     
@@ -100,6 +103,9 @@ AnnotationProperty: skos:relatedMatch
 
     
 Datatype: rdf:PlainLiteral
+
+    
+Datatype: xsd:boolean
 
     
 Datatype: xsd:decimal
@@ -551,7 +557,9 @@ ObjectProperty: OEO_00020182
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
-        rdfs:label "is energy participant of"@en,
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
+        rdfs:label "obsolete is energy participant of",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
 
@@ -561,7 +569,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
 
 rework module structure 
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652
+
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     Domain: 
         OEO_00000150
@@ -577,9 +589,14 @@ ObjectProperty: OEO_00020183
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an input of the artificial object or process.",
-        rdfs:label "is energy input to"@en,
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
+        rdfs:label "obsolete is energy input to",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     SubPropertyOf: 
         OEO_00020182
@@ -589,9 +606,15 @@ ObjectProperty: OEO_00020184
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an output of the artificial object or process.",
-        rdfs:label "is energy output of"@en,
+        rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
+        rdfs:label "obsolete is energy output of",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+
+make obsolete
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2303"
     
     SubPropertyOf: 
         OEO_00020182
@@ -728,10 +751,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270"
 ObjectProperty: OEO_00020506
 
     Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a material entity m and an energy e, where m possesses a disposition d to consume / decrease energy which is realized in a process p, which has an energy decrease process as occurent part which negatively regulates energy e and which occurs in m.",
         rdfs:label "consumes energy"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2246
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270",
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a material entity m and an energy e, where m possesses a disposition d to consume / decrease energy which is realized in a process p, which has an energy decrease process as occurent part which negatively regulates energy e and which occurs in m."
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270"
     
     SubPropertyOf: 
         OEO_00020505
@@ -12020,34 +12043,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2262"
         OEO_00310011,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00020500
     
- 
-Class: OEO_00020514
-
-    Annotations: 
-        rdfs:comment "A base load power plant role is a role of a powerplant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. Usually coal power plants and nuclear power plants bear that role.",
-        rdfs:label "base load power plant role"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
-    
-    SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000023>
-    
-    
-Class: OEO_00020515
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A base load power plant is a power plant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. It possesses the base load power plant role.",
-        rdfs:label "base load power plant"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
-
-    EquivalentTo: 
-        OEO_00000031
-         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020514)
-    
-    SubClassOf: 
-        OEO_00000031
-        
     
 Class: OEO_00020508
 
@@ -12075,7 +12070,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2270"
         <http://purl.obolibrary.org/obo/BFO_0000016>,
         <http://purl.obolibrary.org/obo/BFO_0000054> some OEO_00020003,
         <http://purl.obolibrary.org/obo/RO_0000052> some <http://purl.obolibrary.org/obo/BFO_0000040>
-
+    
+    
 Class: OEO_00020512
 
     Annotations: 
@@ -12105,8 +12101,36 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2277"
     SubClassOf: 
         OEO_00000220,
         OEO_00000530 some OEO_00030005
-        
-        
+    
+    
+Class: OEO_00020514
+
+    Annotations: 
+        rdfs:comment "A base load power plant role is a role of a powerplant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. Usually coal power plants and nuclear power plants bear that role.",
+        rdfs:label "base load power plant role"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
+    
+    SubClassOf: 
+        <http://purl.obolibrary.org/obo/BFO_0000023>
+    
+    
+Class: OEO_00020515
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A base load power plant is a power plant that is intended or operated to provide a relatively constant electrical power output over extended periods to meet the continuously occurring minimum electricity demand of an electricity system. It possesses the base load power plant role.",
+        rdfs:label "base load power plant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2292
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2293"
+    
+    EquivalentTo: 
+        OEO_00000031
+         and (<http://purl.obolibrary.org/obo/RO_0000087> some OEO_00020514)
+    
+    SubClassOf: 
+        OEO_00000031
+    
+    
 Class: OEO_00020516
 
     Annotations: 
@@ -12118,7 +12142,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2297"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>
-
     
     
 Class: OEO_00030000
@@ -14017,6 +14040,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1897
 update oekg annotation
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2295
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2296"
+    
     SubClassOf: 
         OEO_00140040
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -203,13 +203,24 @@ ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
 ObjectProperty: <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED has energy participant"@en,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020462>,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020506>,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is used in the artificial object or process.",
+        rdfs:label "has energy participant"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
+    
+    Range: 
+        OEO_00000150
     
     InverseOf: 
         OEO_00020182
@@ -490,11 +501,24 @@ ObjectProperty: OEO_00010231
 ObjectProperty: OEO_00010234
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED has energy input"@en,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020462>,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020506>,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
+        rdfs:label "has energy input"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+    
+    SubPropertyOf: 
+        <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00010235
@@ -519,9 +543,24 @@ ObjectProperty: OEO_00020180
 ObjectProperty: OEO_00020182
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED is energy participant of"@en,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
+        rdfs:label "is energy participant of"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
+
+move to oeo-shared:
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
+
+rework module structure 
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
+    
+    Domain: 
+        OEO_00000150
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
     
     InverseOf: 
         <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
@@ -530,37 +569,61 @@ ObjectProperty: OEO_00020182
 ObjectProperty: OEO_00020183
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED is energy input to"@en,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an input of the artificial object or process.",
+        rdfs:label "is energy input to"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
+    
+    SubPropertyOf: 
+        OEO_00020182
     
     
 ObjectProperty: OEO_00020184
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED is energy output of"@en,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an output of the artificial object or process.",
+        rdfs:label "is energy output of"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
+    
+    SubPropertyOf: 
+        OEO_00020182
     
     
 ObjectProperty: OEO_00020257
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED has main energy input"@en,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020462>,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020506>,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as major energy input for p.",
+        rdfs:label "has main energy input"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
+    
+    SubPropertyOf: 
+        OEO_00010234
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00020258
 
     Annotations: 
-        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
-        rdfs:label "DEPRECATED has auxilary energy input"@en,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020462>,
-        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020506>,
-        owl:deprecated true
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as input for p, but not as main input.",
+        rdfs:label "has auxilary energy input"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
+    
+    SubPropertyOf: 
+        OEO_00010234
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015>
+    
+    Range: 
+        OEO_00000150
     
     
 ObjectProperty: OEO_00020259

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -203,24 +203,13 @@ ObjectProperty: <http://purl.obolibrary.org/obo/uo#is_unit_of>
 ObjectProperty: <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is used in the artificial object or process.",
-        rdfs:label "has energy participant"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
-    
-    Range: 
-        OEO_00000150
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED has energy participant"@en,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020461>,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020462>,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020506>,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020507>,
+        owl:deprecated true
     
     InverseOf: 
         OEO_00020182
@@ -501,24 +490,11 @@ ObjectProperty: OEO_00010231
 ObjectProperty: OEO_00010234
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
-        rdfs:label "has energy input"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
-    
-    SubPropertyOf: 
-        <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
-    
-    Range: 
-        OEO_00000150
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED has energy input"@en,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020462>,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020506>,
+        owl:deprecated true
     
     
 ObjectProperty: OEO_00010235
@@ -543,24 +519,9 @@ ObjectProperty: OEO_00020180
 ObjectProperty: OEO_00020182
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is used in the artificial object or process.",
-        rdfs:label "is energy participant of"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065
-
-move to oeo-shared:
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1384
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1390
-
-rework module structure 
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/1592
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
-    
-    Domain: 
-        OEO_00000150
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED is energy participant of"@en,
+        owl:deprecated true
     
     InverseOf: 
         <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00010238>
@@ -569,61 +530,37 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1652"
 ObjectProperty: OEO_00020183
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an input of the artificial object or process.",
-        rdfs:label "is energy input to"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
-    
-    SubPropertyOf: 
-        OEO_00020182
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED is energy input to"@en,
+        owl:deprecated true
     
     
 ObjectProperty: OEO_00020184
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an energy and an artificial object or a process, where the energy is an output of the artificial object or process.",
-        rdfs:label "is energy output of"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1057
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1065"
-    
-    SubPropertyOf: 
-        OEO_00020182
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED is energy output of"@en,
+        owl:deprecated true
     
     
 ObjectProperty: OEO_00020257
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as major energy input for p.",
-        rdfs:label "has main energy input"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
-    
-    SubPropertyOf: 
-        OEO_00010234
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED has main energy input"@en,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020462>,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020506>,
+        owl:deprecated true
     
     
 ObjectProperty: OEO_00020258
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as input for p, but not as main input.",
-        rdfs:label "has auxilary energy input"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564"
-    
-    SubPropertyOf: 
-        OEO_00010234
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
-    
-    Range: 
-        OEO_00000150
+        rdfs:comment "The use of this relations has led to unintended semantic dependencies.",
+        rdfs:label "DEPRECATED has auxilary energy input"@en,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020462>,
+        rdfs:seeAlso <https://openenergyplatform.org/ontology/oeo/OEO_00020506>,
+        owl:deprecated true
     
     
 ObjectProperty: OEO_00020259

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -205,7 +205,8 @@ ObjectProperty: <https://openenergyplatform.org/ontology/oeo/oeo-physical/OEO_00
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is used in the artificial object or process.",
         rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
-        rdfs:label "has energy participant"@en,
+        rdfs:label "obsolete has energy participant",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
@@ -508,9 +509,10 @@ ObjectProperty: OEO_00010234
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an input of the artificial object or process.",
         rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
-        rdfs:label "has energy input"@en,
+        rdfs:label "obsolete has energy input",
         rdfs:seeAlso "OEO_00020506 (consumes energy)
 OEO_00020462 (decreases energy)",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
@@ -538,9 +540,10 @@ ObjectProperty: OEO_00010235
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an artificial object or a process and an energy, where the energy is an output of the artificial object or process.",
         rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
-        rdfs:label "has energy output"@en,
+        rdfs:label "obsolete has energy output",
         rdfs:seeAlso "OEO_00020507 (produces energy)
 OEO_00020461 (increases energy)",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/994
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006
 
@@ -647,9 +650,10 @@ ObjectProperty: OEO_00020257
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as major energy input for p.",
         rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
-        rdfs:label "has main energy input"@en,
+        rdfs:label "obsolete has main energy input",
         rdfs:seeAlso "OEO_00020506 (consumes energy)
 OEO_00020462 (decreases energy)",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
 
@@ -672,9 +676,10 @@ ObjectProperty: OEO_00020258
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is required as input for p, but not as main input.",
         rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
-        rdfs:label "has auxilary energy input"@en,
+        rdfs:label "obsolete has auxilary energy input",
         rdfs:seeAlso "OEO_00020506 (consumes energy)
 OEO_00020462 (decreases energy)",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
 
@@ -697,9 +702,10 @@ ObjectProperty: OEO_00020259
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is the intended energy output of p, e.g. for further usage.",
         rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
-        rdfs:label "has main energy output"@en,
+        rdfs:label "obsolete has main energy output",
         rdfs:seeAlso "OEO_00020507 (produces energy)
 OEO_00020461 (increases energy)",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
 
@@ -722,9 +728,10 @@ ObjectProperty: OEO_00020260
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a process p and a kind of energy e, where e is an unintended, unwanted or unevitable output of p, e.g. waste heat.",
         rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
-        rdfs:label "has waste energy output"@en,
+        rdfs:label "obsolete has waste energy output",
         rdfs:seeAlso "OEO_00020507 (produces energy)
 OEO_00020461 (increases energy)",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1530
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1564
 
@@ -860,9 +867,10 @@ ObjectProperty: OEO_00140175
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "p has gross output c iff: p has energy output c, and c is the total amount of energy generated during the process.",
         rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
-        rdfs:label "has gross output"@en,
+        rdfs:label "obsolete has gross output",
         rdfs:seeAlso "OEO_00020507 (produces energy)
 OEO_00020461 (increases energy)",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
 
@@ -889,9 +897,10 @@ ObjectProperty: OEO_00140176
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "p has net output c iff: p has energy output c, and c is the amount of energy delivered to the consumer or fed into a supply grid.",
         rdfs:comment "The usage of this relation has led to unintended semantic dependencies.",
-        rdfs:label "has net output"@en,
+        rdfs:label "obsolete has net output",
         rdfs:seeAlso "OEO_00020507 (produces energy)
 OEO_00020461 (increases energy)",
+        owl:deprecated true,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/394
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/838
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -262,9 +262,6 @@ ObjectProperty: OEO_00010231
     
 ObjectProperty: OEO_00010234
 
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
-    
     
 ObjectProperty: OEO_00010235
 

--- a/src/ontology/edits/oeo-shared-axioms.omn
+++ b/src/ontology/edits/oeo-shared-axioms.omn
@@ -262,6 +262,9 @@ ObjectProperty: OEO_00010231
     
 ObjectProperty: OEO_00010234
 
+    Domain: 
+        <http://purl.obolibrary.org/obo/BFO_0000015> or OEO_00000061
+    
     
 ObjectProperty: OEO_00010235
 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -102,6 +102,4 @@ Datatype: rdf:PlainLiteral
     
 Datatype: xsd:string
 
-
-   
     


### PR DESCRIPTION
## Summary of the discussion

As part of #2190 some relations are deprecated. I used the "deprecate entity" button in Protege. The entities are not deleted but assigned an annotation `owl:deprecated true`.

EDIT: see comment below, the decision was to make the entities obsolete instead of deprecate.

## Type of change (CHANGELOG.md)

### Remove / Obsolete
- has energy participant, has energy input, has energy output and subrelations
- is energy participant, is energy input, is energy output

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
