### PR TITLE
Add new property refers_to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,14 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - base load power plant, base load power plant role (#2293)
 - integrated assessment modeling scenario (#2302)
 - hydrogen supply chain (#2297)
+- "refers to" as subproperty of "is about" (#2306)
+- "refers to energy carrier" as subproperty of "refers to" (#2306)
+- "refers to technology" as subproperty of "refers to" (#2306)
+- "refers to temporal region" as subproperty of "refers to" (#2306)
 
 ### Changed
+- reorder "has spatial region" as subproperty of "refers to" (#2306)
+- reorder "has scenario year" as subproperty of "refers to temporal region" (#2306)
 - update definition source: abated steam reforming hydrogen, fossil steam reforming hydrogen, renewable electrolytic hydrogen (#2277)
 - remove alternative label: solar electrolytic hydrogen (#2277)
 - add alternative labels: commercial sector (#2294)

--- a/src/ontology/edits/catalog-v001.xml
+++ b/src/ontology/edits/catalog-v001.xml
@@ -14,7 +14,7 @@
     <uri id="Imports Wizard Entry" name="https://openenergyplatform.org/ontology/oeo/dev/imports/cco-extracted.owl" uri="../imports/cco-extracted.owl"/>
     <uri id="Imports Wizard Entry" name="https://openenergyplatform.org/ontology/oeo/dev/imports/meno-extracted.owl" uri="../imports/meno-extracted.owl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1784859899111" name="https://openenergyplatform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1784859899111" name="https://openenergyplatform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1776758144454" name="https://openenergyplatform.org/ontology/oeo/oeo-import-edits.owl" uri="oeo-import-edits.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1776758144454" name="https://openenergyplatform.org/ontology/oeo/oeo-physical-axioms/" uri="oeo-physical-axioms.owl"/>
     </group>
 </catalog>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -312,9 +312,6 @@ ObjectProperty: OEO_00010378
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1404
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1441"
     
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
     Domain: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -459,10 +459,11 @@ ObjectProperty: OEO_00020224
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between a scenario and a scenario year to indicate the scenario year of a scenario.",
         rdfs:label "has scenario year"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1335
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1347"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1347
+
+reorder as sub property of refers to temporal region
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
     
     Domain: 
         OEO_00000364

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -576,7 +576,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
 ObjectProperty: OEO_00370001
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity  to an energy carrier that specifies the energy-carrier context of the Information Content Entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity and an energy carrier that specifies context of the information content entity with respect to an energy carrier."@en,       
         rdfs:label "refers to energy carrier"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -576,7 +576,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
 ObjectProperty: OEO_00370001
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity and an energy carrier that specifies context of the information content entity with respect to an energy carrier."@en,       
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity and an energy carrier that specifies context of the information content entity with respect to an energy carrier."@en,
+        rdfs:comment "\"For example, an energy consumption value that refers to the consumption of natural gas.\""@en,
         rdfs:label "refers to energy carrier"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -615,6 +615,7 @@ ObjectProperty: OEO_00370003
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity and a technology that specifies the technological context of the Information Content Entity."@en,
+        rdfs:comment "\"For example, an efficiency value that refers to hydro power technology.\""@en,
         rdfs:label "refers to technology"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -612,7 +612,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
 ObjectProperty: OEO_00370003
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity to a technology that specifies the technological context of the Information Content Entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity and a technology that specifies the technological context of the Information Content Entity."@en,
         rdfs:label "refers to technology"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -596,6 +596,7 @@ ObjectProperty: OEO_00370002
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity and a temporal region that specifies the temporal context of the information content entity."@en,
+        rdfs:comment "\"For example, a data set that refers to the year 2020.\""@en,
         rdfs:label "refers to temporal region"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -310,7 +310,11 @@ ObjectProperty: OEO_00010378
         <http://purl.obolibrary.org/obo/IAO_0000115> "An is-about-relation between an information content entity and a spatial region that describes that the information content entity is about a spatial region.",
         rdfs:label "has spatial region"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1404
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1441"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1441
+
+reorder as sub property of refers to
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
     
     Domain: 
         <http://purl.obolibrary.org/obo/IAO_0000030>

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -316,6 +316,9 @@ reorder as sub property of refers to
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
     
+    SubPropertyOf: 
+        OEO_00370000
+    
     Domain: 
         <http://purl.obolibrary.org/obo/IAO_0000030>
     
@@ -469,6 +472,9 @@ reorder as sub property of refers to temporal region
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
     
+    SubPropertyOf: 
+        OEO_00370002
+    
     Domain: 
         OEO_00000364
     
@@ -548,6 +554,78 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1706"
     
 ObjectProperty: OEO_00140164
 
+    
+ObjectProperty: OEO_00370000
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information content entity to an entity that specifies a context in which the Information content entity is to be interpreted."@en,
+        rdfs:label "refers to"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000001>
+    
+    
+ObjectProperty: OEO_00370001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity  to an energy carrier that specifies the energy-carrier context of the Information Content Entity."@en,
+        rdfs:label "refers to energy carrier"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
+    
+    SubPropertyOf: 
+        OEO_00370000
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        OEO_00020039
+    
+    
+ObjectProperty: OEO_00370002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity to a temporal region that specifies the temporal context of the Information Content Entity."@en,
+        rdfs:label "refers to temporal region"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
+    
+    SubPropertyOf: 
+        OEO_00370000
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000008>
+    
+    
+ObjectProperty: OEO_00370003
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity to a technology that specifies the technological context of the Information Content Entity."@en,
+        rdfs:label "refers to technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
+    
+    SubPropertyOf: 
+        OEO_00370000
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        OEO_00000407
+    
     
 ObjectProperty: OEO_00390023
 
@@ -2389,6 +2467,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1749"
     SubClassOf: 
         OEO_00360020
     
+    
+Class: OEO_00020039
+
     
 Class: OEO_00020072
 

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -312,7 +312,7 @@ ObjectProperty: OEO_00010378
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1404
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1441
 
-reorder as sub property of refers to
+make subproperty of refers to
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
     

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -594,7 +594,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
 ObjectProperty: OEO_00370002
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity to a temporal region that specifies the temporal context of the Information Content Entity."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity and a temporal region that specifies the temporal context of the information content entity."@en,
         rdfs:label "refers to temporal region"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"

--- a/src/ontology/edits/oeo-model.omn
+++ b/src/ontology/edits/oeo-model.omn
@@ -558,7 +558,7 @@ ObjectProperty: OEO_00140164
 ObjectProperty: OEO_00370000
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information content entity to an entity that specifies a context in which the Information content entity is to be interpreted."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between an information content entity and another entity that specifies a context in which the information content entity is to be interpreted."@en,
         rdfs:label "refers to"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"

--- a/src/ontology/oeo-idranges.owl
+++ b/src/ontology/oeo-idranges.owl
@@ -59,7 +59,7 @@ Datatype: idrange:3
 Datatype: idrange:4
 
     Annotations: 
-        allocatedto: "Norman Zielke"
+        allocatedto: "norman"
     
     EquivalentTo: 
         xsd:integer[>= 370000 , <= 379999]

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -134,6 +134,5 @@ ObjectProperty: OEO_00370003
     
 
     
-Class: OEO_00020039
 
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -115,6 +115,12 @@ Datatype: xsd:string
 ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
     
+ObjectProperty: OEO_00010378
+
+    SubPropertyOf: 
+        OEO_00370000
+    
+    
 ObjectProperty: OEO_00370000
 
     Annotations: 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -109,7 +109,6 @@ Datatype: rdf:PlainLiteral
 Datatype: xsd:string
 
     
-ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
     
 ObjectProperty: OEO_00010378

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -78,7 +78,6 @@ A supplementary module is the oeo-physical-axioms module, which contains general
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
 
     
-AnnotationProperty: OEO_00020426
 
     
 AnnotationProperty: dc:contributor

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -113,7 +113,6 @@ Datatype: xsd:string
     
 
     
-ObjectProperty: OEO_00020224
 
     
 ObjectProperty: OEO_00370000

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -101,7 +101,6 @@ AnnotationProperty: owl:versionInfo
 AnnotationProperty: rdfs:comment
 
     
-AnnotationProperty: rdfs:label
 
     
 Datatype: rdf:PlainLiteral

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -117,7 +117,6 @@ Datatype: xsd:string
     
 
     
-ObjectProperty: OEO_00370001
 
     
 ObjectProperty: OEO_00370002

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -73,7 +73,13 @@ A supplementary module is the oeo-physical-axioms module, which contains general
     dct:title "Open Energy Ontology",
     owl:versionInfo "2.13.0"
 
+AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
+
+    
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>
+
+    
+AnnotationProperty: OEO_00020426
 
     
 AnnotationProperty: dc:contributor
@@ -97,11 +103,27 @@ AnnotationProperty: owl:versionInfo
 AnnotationProperty: rdfs:comment
 
     
+AnnotationProperty: rdfs:label
+
+    
 Datatype: rdf:PlainLiteral
 
     
 Datatype: xsd:string
 
+    
+ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 
-   
+    
+ObjectProperty: OEO_00370000
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a quantity value to an entity that specifies a context in which the quantity value is to be interpreted."@en,
+        rdfs:label "refers to"@de,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
+    
+    SubPropertyOf: 
+        <http://purl.obolibrary.org/obo/IAO_0000136>
+    
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -119,7 +119,6 @@ Datatype: xsd:string
     
 
     
-ObjectProperty: OEO_00370002
 
     
 ObjectProperty: OEO_00370003

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -115,7 +115,6 @@ Datatype: xsd:string
     
 
     
-ObjectProperty: OEO_00370000
 
     
 ObjectProperty: OEO_00370001

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -121,7 +121,6 @@ Datatype: xsd:string
     
 
     
-ObjectProperty: OEO_00370003
 
     
 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -132,7 +132,6 @@ ObjectProperty: OEO_00370003
     
 
     
-Class: OEO_00000407
 
     
 Class: OEO_00020039

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -181,6 +181,24 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
         <http://purl.obolibrary.org/obo/BFO_0000008>
     
     
+ObjectProperty: OEO_00370003
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity to a technology that specifies the technological context of the Information Content Entity."@en,
+        rdfs:label "refers to technology"@en,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
+    
+    SubPropertyOf: 
+        OEO_00370000
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        OEO_00000407
+    
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000001>
 
     
@@ -188,6 +206,9 @@ Class: <http://purl.obolibrary.org/obo/BFO_0000008>
 
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000030>
+
+    
+Class: OEO_00000407
 
     
 Class: OEO_00020039

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -157,7 +157,28 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
         OEO_00020039
     
     
+ObjectProperty: OEO_00370002
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity to a temporal region that specifies the temporal context of the Information Content Entity."@en,
+        rdfs:label "refers to temporal region"@de,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
+    
+    SubPropertyOf: 
+        OEO_00370000
+    
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000008>
+    
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000001>
+
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000008>
 
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000030>

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -150,10 +150,19 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
     SubPropertyOf: 
         OEO_00370000
     
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        OEO_00020039
+    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000001>
 
     
 Class: <http://purl.obolibrary.org/obo/IAO_0000030>
+
+    
+Class: OEO_00020039
 
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -111,7 +111,6 @@ Datatype: xsd:string
     
 
     
-ObjectProperty: OEO_00010378
 
     
 ObjectProperty: OEO_00020224

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -131,7 +131,6 @@ ObjectProperty: OEO_00370003
 Class: <http://purl.obolibrary.org/obo/BFO_0000008>
 
     
-Class: <http://purl.obolibrary.org/obo/IAO_0000030>
 
     
 Class: OEO_00000407

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -128,7 +128,6 @@ ObjectProperty: OEO_00370003
     
 
     
-Class: <http://purl.obolibrary.org/obo/BFO_0000008>
 
     
 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -73,7 +73,6 @@ A supplementary module is the oeo-physical-axioms module, which contains general
     dct:title "Open Energy Ontology",
     owl:versionInfo "2.13.0"
 
-AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000115>
 
     
 AnnotationProperty: <http://purl.obolibrary.org/obo/IAO_0000233>

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -118,7 +118,7 @@ ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
 ObjectProperty: OEO_00370000
 
     Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a quantity value to an entity that specifies a context in which the quantity value is to be interpreted."@en,
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information content entity to an entity that specifies a context in which the Information content entity is to be interpreted."@en,
         rdfs:label "refers to"@de,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
@@ -126,4 +126,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
     SubPropertyOf: 
         <http://purl.obolibrary.org/obo/IAO_0000136>
     
+    Domain: 
+        <http://purl.obolibrary.org/obo/IAO_0000030>
+    
+    Range: 
+        <http://purl.obolibrary.org/obo/BFO_0000001>
+    
+    
+Class: <http://purl.obolibrary.org/obo/BFO_0000001>
+
+    
+Class: <http://purl.obolibrary.org/obo/IAO_0000030>
+
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -121,6 +121,12 @@ ObjectProperty: OEO_00010378
         OEO_00370000
     
     
+ObjectProperty: OEO_00020224
+
+    SubPropertyOf: 
+        OEO_00370002
+    
+    
 ObjectProperty: OEO_00370000
 
     Annotations: 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -117,87 +117,21 @@ ObjectProperty: <http://purl.obolibrary.org/obo/IAO_0000136>
     
 ObjectProperty: OEO_00010378
 
-    SubPropertyOf: 
-        OEO_00370000
-    
     
 ObjectProperty: OEO_00020224
 
-    SubPropertyOf: 
-        OEO_00370002
-    
     
 ObjectProperty: OEO_00370000
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information content entity to an entity that specifies a context in which the Information content entity is to be interpreted."@en,
-        rdfs:label "refers to"@de,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
-    
-    SubPropertyOf: 
-        <http://purl.obolibrary.org/obo/IAO_0000136>
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000001>
-    
     
 ObjectProperty: OEO_00370001
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity  to an energy carrier that specifies the energy-carrier context of the Information Content Entity."@en,
-        rdfs:label "refers to energy carrier"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
-    
-    SubPropertyOf: 
-        OEO_00370000
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        OEO_00020039
-    
     
 ObjectProperty: OEO_00370002
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity to a temporal region that specifies the temporal context of the Information Content Entity."@en,
-        rdfs:label "refers to temporal region"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
-    
-    SubPropertyOf: 
-        OEO_00370000
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000008>
-    
     
 ObjectProperty: OEO_00370003
 
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity to a technology that specifies the technological context of the Information Content Entity."@en,
-        rdfs:label "refers to technology"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
-    
-    SubPropertyOf: 
-        OEO_00370000
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/IAO_0000030>
-    
-    Range: 
-        OEO_00000407
-    
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000001>
 

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -149,7 +149,7 @@ ObjectProperty: OEO_00370001
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity  to an energy carrier that specifies the energy-carrier context of the Information Content Entity."@en,
-        rdfs:label "refers to energy carrier"@de,
+        rdfs:label "refers to energy carrier"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
     
@@ -167,7 +167,7 @@ ObjectProperty: OEO_00370002
 
     Annotations: 
         <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity to a temporal region that specifies the temporal context of the Information Content Entity."@en,
-        rdfs:label "refers to temporal region"@de,
+        rdfs:label "refers to temporal region"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
     

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -126,7 +126,6 @@ ObjectProperty: OEO_00370002
 ObjectProperty: OEO_00370003
 
     
-Class: <http://purl.obolibrary.org/obo/BFO_0000001>
 
     
 Class: <http://purl.obolibrary.org/obo/BFO_0000008>

--- a/src/ontology/oeo.omn
+++ b/src/ontology/oeo.omn
@@ -139,6 +139,18 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
         <http://purl.obolibrary.org/obo/BFO_0000001>
     
     
+ObjectProperty: OEO_00370001
+
+    Annotations: 
+        <http://purl.obolibrary.org/obo/IAO_0000115> "A relation that relates a Information Content Entity  to an energy carrier that specifies the energy-carrier context of the Information Content Entity."@en,
+        rdfs:label "refers to energy carrier"@de,
+        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2272
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2306"
+    
+    SubPropertyOf: 
+        OEO_00370000
+    
+    
 Class: <http://purl.obolibrary.org/obo/BFO_0000001>
 
     


### PR DESCRIPTION
## Summary of the discussion

Implement new property "refers to" with subproperties, mainly for quantity values, and reorder existing concepts under this property.

This PR will be closes #2272. After that I can continue with #2259, because of rearrangement of some concepts.  

## Type of change (CHANGELOG.md)

### Add
- "refers to" as subproperty of "is about" 
- "refers to energy carrier" as subproperty of "refers to"
- "refers to technology" as subproperty of "refers to"
- "refers to temporal region" as subproperty of "refers to"

### Update
- reorder "has spatial region" as subproperty of "refers to"
- reorder "has scenario year" as subproperty of "refers to temporal region"

## Workflow checklist

### Automation
Closes #2272

### PR-Assignee
- [x] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [x] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
