### PR TITLE
finalize occurs in axioms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,8 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - import from BFO/RO: occurs in (#2305)
 
 ### Changed
-- add axiom "occurs in" as replacement for "participates in": ... (#2305)
-- add axiom "occurs in" for: `electricity generation process`, `photovoltaic energy transformation`, `fuel-powered electricity generation process`, `gas turbine process`, `power-to-methane process`, `curtailment`, `power-to-gas process`, `steam-electric process`, `hydro energy transformation`, `wind energy transformation`, `hydroelectric energy transformation`, `marine current energy transformation`, `marine tidal energy transformation`, `marine wave energy transformation`, `marine current energy transformation`, `mineral oil refining process`, `combined heat and power generating process`, `power-to-fuel process`, `power-to-ammonia process` (#2305)
-- remove axiom "participates in" for: `power plant`, `photovoltaic cell`, `fueled power plant`, `fueled power unit`, `gas turbine`, `power-to-methane system`. `power generating unit`, `power-to-gas system`, `steam turbine`, `water turbine`, `wind rotor`, `hydro power unit`, `hydro power plant`, `marine current energy converting unit`, `marine tidal energy converting unit`, `marine wave energy converting unit`, `marine current energy power plant`, `marine tidal energy power plant`, `marine wave energy power plant`, `mineral oil refinery`, `combined heat and power generating unit`, `combined heat and power plant`, `power-to-fuel system`, `power-to-ammonia system` (#2305)
+- add axiom "occurs in" for: electricity generation process, photovoltaic energy transformation, fuel-powered electricity generation process, gas turbine process, power-to-methane process, curtailment, power-to-gas process, steam-electric process, hydro energy transformation, wind energy transformation, hydroelectric energy transformation, marine current energy transformation, marine tidal energy transformation, marine wave energy transformation, marine current energy transformation, mineral oil refining process, combined heat and power generating process, power-to-fuel process, power-to-ammonia process (#2310) (#2313)
+- remove axiom "participates in" for: power plant, photovoltaic cell, fueled power plant, fueled power unit, gas turbine, power-to-methane system. power generating unit, power-to-gas system, steam turbine, water turbine, wind rotor, hydro power unit, hydro power plant, marine current energy converting unit, marine tidal energy converting unit, marine wave energy converting unit, marine current energy power plant, marine tidal energy power plant, marine wave energy power plant, mineral oil refinery, combined heat and power generating unit, combined heat and power plant, power-to-fuel system, power-to-ammonia system (#2310) (#2313)
 - reorder "has spatial region" as subproperty of "refers to" (#2306)
 - reorder "has scenario year" as subproperty of "refers to temporal region" (#2306)
 - update definition source: abated steam reforming hydrogen, fossil steam reforming hydrogen, renewable electrolytic hydrogen (#2277)
@@ -1213,7 +1212,7 @@ We added a lot of classes that are relevant for the OEKG development, i.e. techn
 
 ### Removed
 
-- `ObjectProperty` `has_stateofmatter` (#39)
+- ObjectProperty has_stateofmatter (#39)
 - some superclasses of unsatisfiable classes and some that made the
   ontology inconsistent (#51)
 - contact and subclasses (#101)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -119,6 +119,9 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000054>
 
+
+ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000066>
+
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000117>
 
@@ -6309,7 +6312,7 @@ pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
         <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010107,
         OEO_00020461 some OEO_00000139,
         OEO_00020462 some OEO_00010097,
-        OEO_00370007 some OEO_00010108
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010108
     
     
 Class: OEO_00010099
@@ -6346,7 +6349,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
         <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010101,
-        OEO_00370007 some OEO_00010109
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010109
     
     
 Class: OEO_00010100
@@ -6451,7 +6454,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
         <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010106,
-        OEO_00370007 some OEO_00010110
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010110
     
     
 Class: OEO_00010104
@@ -7151,7 +7154,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     
     SubClassOf: 
         OEO_00330007,
-        OEO_00370007 some OEO_00000335
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000335
     
     
 Class: OEO_00010217
@@ -7194,7 +7197,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
             (OEO_00000006
              and OEO_00000441),
         OEO_00000533 some OEO_00010018,
-        OEO_00370007 some OEO_00000269
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000269
     
     
 Class: OEO_00010218
@@ -7308,7 +7311,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000007))),
         OEO_00000533 some OEO_00010221,
-        OEO_00370007 some OEO_00330010
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00330010
     
     
 Class: OEO_00010223
@@ -8360,7 +8363,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
         OEO_00000533 some OEO_00010316,
         OEO_00020461 some OEO_00000007,
         OEO_00020462 some OEO_00000007,
-        OEO_00370007 some OEO_00010318
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010318
     
     
 Class: OEO_00010316
@@ -10273,7 +10276,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000139))),
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044,
-        OEO_00370007 some OEO_00000448
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000448
     
     
 Class: OEO_00020045
@@ -10389,7 +10392,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000032,
         OEO_00020461 some OEO_00000139,
         OEO_00020462 some OEO_00000384,
-        OEO_00370007 some OEO_00000032
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000032
     
     
 Class: OEO_00020050
@@ -10698,7 +10701,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000334,
-        OEO_00370007 some OEO_00000031
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000031
     
     
 Class: OEO_00020136
@@ -12602,7 +12605,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000175,
         <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147,
         OEO_00000500 some OEO_00000148,
-        OEO_00370007 some OEO_00000175
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000175
     
     
 Class: OEO_00050002
@@ -12947,7 +12950,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
         OEO_00020461 some OEO_00000139,
         OEO_00020462 some OEO_00000207,
-        OEO_00370007 some OEO_00000396
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000396
     
     
 Class: OEO_00090000
@@ -13055,7 +13058,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
         OEO_00020003,
         OEO_00020461 some OEO_00000150,
         OEO_00020462 some OEO_00000218,
-        OEO_00370007 some OEO_00000442
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000442
     
     
 Class: OEO_00110005
@@ -13086,7 +13089,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000139))),
-        OEO_00370007 some OEO_00010085
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010085
     
     
 Class: OEO_00110019
@@ -14516,7 +14519,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
              and (<http://purl.obolibrary.org/obo/RO_0019001> some 
                 (OEO_00000139
                  and OEO_00000207)))),
-        OEO_00370007 some OEO_00240010
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00240010
     
     
 Class: OEO_00240010
@@ -14671,7 +14674,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
         OEO_00020003,
         OEO_00000500 some OEO_00240012,
         OEO_00000500 some OEO_00240013,
-        OEO_00370007 some OEO_00000334
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000334
     
     
 Class: OEO_00240015
@@ -15617,7 +15620,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
         <http://purl.obolibrary.org/obo/BFO_0000117> some OEO_00140038,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000185,
         OEO_00000532 some OEO_00000099,
-        OEO_00370007 some OEO_00000185
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000185
     
     
 Class: OEO_00310028
@@ -17133,7 +17136,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     SubClassOf: 
         OEO_00020003,
         OEO_00000532 some OEO_00000331,
-        OEO_00370007 some OEO_00330009
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00330009
     
     
 Class: OEO_00330008

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -119,7 +119,7 @@ ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000051>
     
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000054>
 
-
+    
 ObjectProperty: <http://purl.obolibrary.org/obo/BFO_0000066>
 
     
@@ -831,22 +831,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1006"
     
 ObjectProperty: OEO_00240025
 
-    
-ObjectProperty: OEO_00370007
-
-    Annotations: 
-        <http://purl.obolibrary.org/obo/IAO_0000115> "b occurs_in c =def b is a process and c is a material entity or immaterial entity& there exists a spatiotemporal region r and b occupies_spatiotemporal_region r.& forall(t) if b exists_at t then c exists_at t & there exist spatial regions s and s’ where & b spatially_projects_onto s at t& c is occupies_spatial_region s’ at t& s is a proper_continuant_part_of s’ at t."@en,
-        rdfs:comment "Paraphrase of definition: a relation between a process and an independent continuant, in which the process takes place entirely within the independent continuant."@en,
-        rdfs:label "occurs in"@en,
-        OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
-    
-    Domain: 
-        <http://purl.obolibrary.org/obo/BFO_0000003>
-    
-    Range: 
-        <http://purl.obolibrary.org/obo/BFO_0000004>
-    
     
 ObjectProperty: owl:topObjectProperty
 
@@ -6300,6 +6284,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     
     SubClassOf: 
         OEO_00110005,
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010108,
         
             Annotations: rdfs:comment "reintroduce axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
@@ -6311,8 +6296,7 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
         <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010107,
         OEO_00020461 some OEO_00000139,
-        OEO_00020462 some OEO_00010097,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010108
+        OEO_00020462 some OEO_00010097
     
     
 Class: OEO_00010099
@@ -6343,13 +6327,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000139))),
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010109,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         
             Annotations: OEO_00020426 "replace 'has input' with 'causally downstream of or within'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010101,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010109
+        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010101
     
     
 Class: OEO_00010100
@@ -6448,13 +6432,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000139))),
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010110,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         
             Annotations: OEO_00020426 "replace 'has input' with 'causally downstream of or within'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
-        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010106,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010110
+        <http://purl.obolibrary.org/obo/RO_0002427> some OEO_00010106
     
     
 Class: OEO_00010104
@@ -7191,13 +7175,13 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000007))),
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000269,
         <http://purl.obolibrary.org/obo/BFO_0000117> some OEO_00010219,
         <http://purl.obolibrary.org/obo/BFO_0000117> some OEO_00010220,
         OEO_00000532 some 
             (OEO_00000006
              and OEO_00000441),
-        OEO_00000533 some OEO_00010018,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000269
+        OEO_00000533 some OEO_00010018
     
     
 Class: OEO_00010218
@@ -7310,8 +7294,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000007))),
-        OEO_00000533 some OEO_00010221,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00330010
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00330010,
+        OEO_00000533 some OEO_00010221
     
     
 Class: OEO_00010223
@@ -8359,11 +8343,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     SubClassOf: 
         OEO_00010127,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140033,
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010318,
         OEO_00000532 some OEO_00000115,
         OEO_00000533 some OEO_00010316,
         OEO_00020461 some OEO_00000007,
-        OEO_00020462 some OEO_00000007,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00010318
+        OEO_00020462 some OEO_00000007
     
     
 Class: OEO_00010316
@@ -10275,8 +10259,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000139))),
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000448
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000448,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000044
     
     
 Class: OEO_00020045
@@ -10389,10 +10373,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     
     SubClassOf: 
         OEO_00020003,
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000032,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000032,
         OEO_00020461 some OEO_00000139,
-        OEO_00020462 some OEO_00000384,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000032
+        OEO_00020462 some OEO_00000384
     
     
 Class: OEO_00020050
@@ -10700,8 +10684,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     
     SubClassOf: 
         <http://purl.obolibrary.org/obo/BFO_0000015>,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000334,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000031
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000031,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000334
     
     
 Class: OEO_00020136
@@ -12601,11 +12585,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000139))),
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000175,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000174,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000175,
         <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147,
-        OEO_00000500 some OEO_00000148,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000175
+        OEO_00000500 some OEO_00000148
     
     
 Class: OEO_00050002
@@ -12943,14 +12927,14 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     
     SubClassOf: 
         OEO_00020003,
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000396,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000010,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000396,
         
             Annotations: OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/736
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/766"
         OEO_00020461 some OEO_00000139,
-        OEO_00020462 some OEO_00000207,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000396
+        OEO_00020462 some OEO_00000207
     
     
 Class: OEO_00090000
@@ -13056,9 +13040,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     
     SubClassOf: 
         OEO_00020003,
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000442,
         OEO_00020461 some OEO_00000150,
-        OEO_00020462 some OEO_00000218,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000442
+        OEO_00020462 some OEO_00000218
     
     
 Class: OEO_00110005
@@ -14672,9 +14656,9 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     
     SubClassOf: 
         OEO_00020003,
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000334,
         OEO_00000500 some OEO_00240012,
-        OEO_00000500 some OEO_00240013,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000334
+        OEO_00000500 some OEO_00240013
     
     
 Class: OEO_00240015
@@ -15617,10 +15601,10 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00240000))),
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000185,
         <http://purl.obolibrary.org/obo/BFO_0000117> some OEO_00140038,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000185,
-        OEO_00000532 some OEO_00000099,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00000185
+        OEO_00000532 some OEO_00000099
     
     
 Class: OEO_00310028
@@ -17135,8 +17119,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     
     SubClassOf: 
         OEO_00020003,
-        OEO_00000532 some OEO_00000331,
-        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00330009
+        <http://purl.obolibrary.org/obo/BFO_0000066> some OEO_00330009,
+        OEO_00000532 some OEO_00000331
     
     
 Class: OEO_00330008


### PR DESCRIPTION
## Summary of the discussion

This is based on #2255 and #2305: 
- In #2310 a placeholder relation `oeo:occurs in` (OEO_00370007) has been created and used. 
- Now that `bfo:occurs in` has been added in #2311, the placeholder relation has to be replaced in the axioms by `bfo:occurs in` (BFO_0000066)
- The placeholder relation has been deleted.


## Type of change (CHANGELOG.md)

### Update
- all axioms that have been added in #2310

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
