### PR TITLE
replace participates in with has participant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and the versioning adheres to [Semantic Versioning](http://semver.org/spec/v2.0.
 - Updated oekg annotation: decarbonisation pathway, sufficiency, policy instrument, acceptance (#2296)
 - Updated oekg annotation: study report due to legal obligation, model coupling, regionalisation, model intercomparison study, scenario projection comparison (#2296)
 - Updated oekg annotation: electricity grid, greenhouse gas emission, negative emission, gas grid, heating grid, electrical energy share, sector coupling, energy conversion efficiency, renewable energy share, gross electricity generation, CO2 emission, flexibility, resilience, life cycle assessment (#2296)
+- add "has participant" axiom: hydro energy process, hydroelectric energy transformation, marine current/tidal/wave energy transformation, mineral oil refinery process, solar tracking and subclasses, combined heat and power genering process, combustion fuel transport, hydrogen transport, power-to-fuel process, power-to-ammonia-process, power-to-methane process, power-to-gas process (#2314)
+- remove "participates in" axiom from: solar tracked receiving surface, single/two axis tracked receiving surface, combined heat and power generating unit, filling station, hydrogen station (#2314)
 
 ### Removed
 

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9037,11 +9037,11 @@ Class: OEO_00010398
         <http://purl.obolibrary.org/obo/IAO_0000115> "A solar tracked receiving surface is a solar radiation receiving surface that participates in solar tracking.",
         rdfs:label "solar tracked receiving surface"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
-    
-    EquivalentTo: 
-        OEO_00020199
-         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010395)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448
+
+remove equivalence axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00020199
@@ -9053,11 +9053,11 @@ Class: OEO_00010399
         <http://purl.obolibrary.org/obo/IAO_0000115> "A single axis tracked receiving surface is a solar radiation receiving surface that participates in single axis tracking.",
         rdfs:label "single axis tracked receiving surface"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
-    
-    EquivalentTo: 
-        OEO_00020199
-         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010396)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448
+
+remove equivalence axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00020199
@@ -9069,11 +9069,11 @@ Class: OEO_00010400
         <http://purl.obolibrary.org/obo/IAO_0000115> "A two axis tracked receiving surface is a solar radiation receiving surface that participates in two axis tracking.",
         rdfs:label "two axis tracked receiving surface"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
-    
-    EquivalentTo: 
-        OEO_00020199
-         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010397)
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448
+
+remove equivalence axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00020199

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8372,11 +8372,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2233
 
 add occurs in axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00010127,
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00140033,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010318,
         OEO_00000532 some OEO_00000115,
         OEO_00000533 some OEO_00010316,
         OEO_00020461 some OEO_00000007,

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -17184,9 +17184,10 @@ replace energy-participant axioms
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2120
 
-add occurs in axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+add occurs in and has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     EquivalentTo: 
         (<http://purl.obolibrary.org/obo/BFO_0000117> some 
@@ -17199,6 +17200,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     
     SubClassOf: 
         OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00330009,
         OEO_00000532 some OEO_00000331,
         OEO_00370007 some OEO_00330009
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -8999,10 +8999,15 @@ Class: OEO_00010395
         <http://purl.obolibrary.org/obo/IAO_0000118> "Sonnennachführung"@de,
         rdfs:label "solar tracking"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
-        <http://purl.obolibrary.org/obo/BFO_0000015>
+        <http://purl.obolibrary.org/obo/BFO_0000015>,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010398
     
     
 Class: OEO_00010396
@@ -9012,7 +9017,11 @@ Class: OEO_00010396
         <http://purl.obolibrary.org/obo/IAO_0000118> "Einachs-Nachführung"@de,
         rdfs:label "single axis tracking"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00010395
@@ -9025,7 +9034,10 @@ Class: OEO_00010397
         <http://purl.obolibrary.org/obo/IAO_0000118> "Zweiachs-Nachführung"@de,
         rdfs:label "two axis tracking"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1076
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1448
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00010395

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -14555,9 +14555,10 @@ replace energy-participant axioms
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2120
 
-add occurs in axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+add occurs in and has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00020003,
@@ -14569,6 +14570,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
              and (<http://purl.obolibrary.org/obo/RO_0019001> some 
                 (OEO_00000139
                  and OEO_00000207)))),
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240010,
         OEO_00370007 some OEO_00240010
     
     
@@ -14597,7 +14599,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2233
 
 Remove participates in axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     EquivalentTo: 
         OEO_00020102
@@ -14610,7 +14613,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
         <http://purl.obolibrary.org/obo/BFO_0000051> some OEO_00000188,
         <http://purl.obolibrary.org/obo/BFO_0000051> some 
             (OEO_00000210 or OEO_00140102),
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00020107,
         <http://purl.obolibrary.org/obo/RO_0000085> some 
             (OEO_00010386
              and OEO_00010387)

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -13062,10 +13062,15 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2233
 
 add occurs in axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00020003,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000442,
         OEO_00020461 some OEO_00000150,
         OEO_00020462 some OEO_00000218,
         OEO_00370007 some OEO_00000442

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6331,7 +6331,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2120
 
 add occurs in axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00110005,
@@ -6341,6 +6345,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000139))),
+        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010109,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
         
             Annotations: OEO_00020426 "replace 'has input' with 'causally downstream of or within'

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7178,7 +7178,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2120
 
 add occurs in axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00020003,
@@ -7190,6 +7194,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000007))),
         <http://purl.obolibrary.org/obo/BFO_0000117> some OEO_00010219,
         <http://purl.obolibrary.org/obo/BFO_0000117> some OEO_00010220,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000269,
         OEO_00000532 some 
             (OEO_00000006
              and OEO_00000441),

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -13094,7 +13094,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2120
 
 add occurs in axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00110004,
@@ -13104,6 +13108,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000139))),
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010085,
         OEO_00370007 some OEO_00010085
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -16574,11 +16574,16 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1299
 
 remove energy axioms
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2190
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2233"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2233
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00320038,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000099
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000099,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00320058
     
     
 Class: OEO_00320040
@@ -16909,16 +16914,15 @@ Class: OEO_00320058
         <http://purl.obolibrary.org/obo/IAO_0000118> "Tankstelle"@de,
         rdfs:label "filling station"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1308
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357
+
+remove participates in axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00020102,
-        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00320016,
-        <http://purl.obolibrary.org/obo/RO_0000056> some 
-            (OEO_00320039
-             and (<http://purl.obolibrary.org/obo/RO_0000057> some 
-                (OEO_00320056
-                 and (<http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00010023))))
+        <http://purl.obolibrary.org/obo/BFO_0000050> some OEO_00320016
     
     
 Class: OEO_00320059

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -16932,11 +16932,14 @@ Class: OEO_00320059
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserstofftankstelle"@de,
         rdfs:label "hydrogen station"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1308
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357
+
+remove participates in axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
-        OEO_00320058,
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00320060
+        OEO_00320058
     
     
 Class: OEO_00320060
@@ -16946,11 +16949,16 @@ Class: OEO_00320060
         <http://purl.obolibrary.org/obo/IAO_0000118> "Wasserstofftransport"@de,
         rdfs:label "hydrogen transport"@en,
         OEO_00020426 "issue: https://github.com/OpenEnergyPlatform/ontology/issues/1308
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1357
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00320039,
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000220
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000220,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00320059
     
     
 Class: OEO_00320061

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -9024,7 +9024,8 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
-        OEO_00010395
+        OEO_00010395,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010399
     
     
 Class: OEO_00010397
@@ -9040,7 +9041,8 @@ issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
-        OEO_00010395
+        OEO_00010395,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010400
     
     
 Class: OEO_00010398

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7143,7 +7143,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2120
 
 add occurs in axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     EquivalentTo: 
         OEO_00330007
@@ -7151,6 +7155,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
     
     SubClassOf: 
         OEO_00330007,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000335,
         OEO_00370007 some OEO_00000335
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6302,6 +6302,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
 pull-request: https://github.com/OpenEnergyPlatform/ontology/pull/1137"
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010108,
         
             Annotations: OEO_00020426 "replace 'has input' with 'causally downstream of or within'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6441,7 +6441,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2120
 
 add occurs in axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+
+add has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00110005,
@@ -6452,6 +6456,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000139))),
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010110,
         
             Annotations: OEO_00020426 "replace 'has input' with 'causally downstream of or within'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -6345,8 +6345,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000139))),
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010109,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010105,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00010109,
         
             Annotations: OEO_00020426 "replace 'has input' with 'causally downstream of or within'
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/1023
@@ -9541,8 +9541,8 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/1601"
     
     SubClassOf: 
         OEO_00010434,
-        (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010109)
-         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010099)
+        (<http://purl.obolibrary.org/obo/IAO_0000136> some OEO_00010110)
+         and (<http://purl.obolibrary.org/obo/RO_0000056> some OEO_00010103)
     
     
 Class: OEO_00010438
@@ -14572,7 +14572,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
              and (<http://purl.obolibrary.org/obo/RO_0019001> some 
                 (OEO_00000139
                  and OEO_00000207)))),
-        <http://purl.obolibrary.org/obo/RO_0000056> some OEO_00240010,
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00240010,
         OEO_00370007 some OEO_00240010
     
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -7316,9 +7316,10 @@ replace energy-participant axioms
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2053
 pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2120
 
-add occurs in axiom
-issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+add occurs in and has participant axiom
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     SubClassOf: 
         OEO_00020003,
@@ -7328,6 +7329,7 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000007))),
+        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00330010,
         OEO_00000533 some OEO_00010221,
         OEO_00370007 some OEO_00330010
     

--- a/src/ontology/edits/oeo-physical.omn
+++ b/src/ontology/edits/oeo-physical.omn
@@ -12585,7 +12585,11 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2120
 
 add occurs in axiom
 issue: https://github.com/OpenEnergyPlatform/ontology/issues/2305
-pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310
+
+remove axiom to fueled power plant
+issue: https://github.com/OpenEnergyPlatform/ontology/issues/2255
+pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2314"
     
     EquivalentTo: 
         OEO_00240014
@@ -12598,7 +12602,6 @@ pull request: https://github.com/OpenEnergyPlatform/ontology/pull/2310"
          and (<http://purl.obolibrary.org/obo/BFO_0000117> some 
             (<https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014>
              and (<http://purl.obolibrary.org/obo/RO_0019001> some OEO_00000139))),
-        <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000174,
         <http://purl.obolibrary.org/obo/RO_0000057> some OEO_00000175,
         <http://purl.obolibrary.org/obo/RO_0002418> some OEO_00000147,
         OEO_00000500 some OEO_00000148,


### PR DESCRIPTION
## Summary of the discussion

This PR is based on the discussion in #2255.
As a second step, we replace some axioms with participates in with has participant, see table.

## Type of change (CHANGELOG.md)

### Update
- add "has participant" axiom: hydro energy process, hydroelectric energy transformation, marine current/tidal/wave energy transformation, mineral oil refinery process, solar tracking and subclasses, combined heat and power genering process, combustion fuel transport, hydrogen transport, power-to-fuel process, power-to-ammonia-process, power-to-methane process, power-to-gas process (#2314)
- remove "participates in" axiom from: solar tracked receiving surface, single/two axis tracked receiving surface, combined heat and power generating unit, filling station, hydrogen station

## Workflow checklist

### Automation
Closes #

### PR-Assignee
- [ ] 🐙 Follow the [Pull Request Workflow](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ontology/blob/dev/CHANGELOG.md)
- [ ] 📙 Add #'s to `term tracker annotation`

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guide](https://github.com/OpenEnergyPlatform/ontology/wiki/Pull-request-workflow#reviewer-guide-check-changes-introduced-by-a-pull-request)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
